### PR TITLE
fix(appium-tizen-tv-driver): correct params to TizenRemote constructor

### DIFF
--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -3,10 +3,7 @@ import {TizenRemote, Keys as KEYS} from '@headspinio/tizen-remote';
 import {RC_OPTS} from './driver';
 
 export async function pairRemote({host}) {
-  const rc = new TizenRemote({
-    ...RC_OPTS,
-    host,
-  });
+  const rc = new TizenRemote(host, RC_OPTS);
 
   const token = await rc.getToken();
   if (token) {


### PR DESCRIPTION
I changed the constructor signature and neglected to update `rc-pair`