### PR TITLE
feat(appium-tizen-tv-driver): keypress support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,18 @@
       }
     },
     {
+      "files": "packages/appium-tizen-tv-driver/lib/scripts.js",
+      "env": {
+        "browser": true
+      },
+      "rules": {
+        "promise/no-native": 0
+      },
+      "globals": {
+        "tizen": false
+      }
+    },
+    {
       "files": "packages/tizen-sample-app/js/**/*.js",
       "env": {
         "browser": true

--- a/.wallaby.js
+++ b/.wallaby.js
@@ -8,6 +8,9 @@ module.exports = (wallaby) => {
     debug: true,
     env: {
       type: 'node',
+      params: {
+        env: 'DEBUG=tizen-remote*'
+      }
     },
     files: [
       './packages/*/*.js',
@@ -18,6 +21,7 @@ module.exports = (wallaby) => {
       '!./packages/*/gulpfile.js',
       '!./packages/*/scripts/**',
       './packages/*/test/**/fixtures/**/*',
+      './packages/*/test/**/helpers.js',
       './babel.config.json',
     ],
     testFramework: 'mocha',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/teen_process": "1.16.1",
         "@types/ws": "8.5.3",
         "@types/yargs": "17.0.11",
+        "@wdio/types": "7.24.0",
         "appium": "^2.0.0-beta.43",
         "babel-plugin-source-map-support": "2.2.0",
         "cross-env": "7.0.3",
@@ -63,7 +64,7 @@
     },
     "../../appium/appium/packages/types": {
       "name": "@appium/types",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/schema": "^0.0.9",
@@ -4908,6 +4909,22 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@wdio/config/node_modules/@wdio/types": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "got": "^11.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.6.2"
+      }
+    },
     "node_modules/@wdio/logger": {
       "version": "7.19.0",
       "dev": true,
@@ -4998,9 +5015,10 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "7.20.7",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-wJZ+1lIHFz5aWXSO+k91wX8tfZdpyX4YYoker5xfC4zvM7ypyK81dZyiE5whS+QFL3VTCPP8dXNjwX5f5h+YEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "got": "^11.8.1"
@@ -5010,6 +5028,11 @@
       },
       "peerDependencies": {
         "typescript": "^4.6.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wdio/utils": {
@@ -5023,6 +5046,22 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@wdio/types": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "got": "^11.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.6.2"
       }
     },
     "node_modules/abbrev": {
@@ -7956,6 +7995,22 @@
       "version": "0.0.1029085",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/devtools/node_modules/@wdio/types": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "got": "^11.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.6.2"
+      }
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -16875,6 +16930,22 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/webdriver/node_modules/@wdio/types": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "got": "^11.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.6.2"
+      }
+    },
     "node_modules/webdriverio": {
       "version": "7.20.9",
       "dev": true,
@@ -16910,6 +16981,22 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/types": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "got": "^11.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.6.2"
       }
     },
     "node_modules/webdriverio/node_modules/brace-expansion": {
@@ -20885,6 +20972,18 @@
         "@wdio/utils": "7.20.7",
         "deepmerge": "^4.0.0",
         "glob": "^8.0.3"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+          "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^18.0.0",
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "@wdio/logger": {
@@ -20944,7 +21043,9 @@
       }
     },
     "@wdio/types": {
-      "version": "7.20.7",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-wJZ+1lIHFz5aWXSO+k91wX8tfZdpyX4YYoker5xfC4zvM7ypyK81dZyiE5whS+QFL3VTCPP8dXNjwX5f5h+YEw==",
       "dev": true,
       "requires": {
         "@types/node": "^18.0.0",
@@ -20958,6 +21059,18 @@
         "@wdio/logger": "7.19.0",
         "@wdio/types": "7.20.7",
         "p-iteration": "^1.1.8"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+          "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^18.0.0",
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "abbrev": {
@@ -22958,6 +23071,18 @@
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.1",
         "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+          "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^18.0.0",
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "devtools-protocol": {
@@ -28768,6 +28893,18 @@
         "got": "^11.0.2",
         "ky": "0.30.0",
         "lodash.merge": "^4.6.1"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+          "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^18.0.0",
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "webdriverio": {
@@ -28803,6 +28940,16 @@
         "webdriver": "7.20.8"
       },
       "dependencies": {
+        "@wdio/types": {
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.7.tgz",
+          "integrity": "sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^18.0.0",
+            "got": "^11.8.1"
+          }
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tunnel:sdb": "npm run tunnel:base --port=26101",
     "sdb:local:connect": "sdb connect $npm_config_device:$npm_config_port",
     "sdb:local:disconnect": "sdb disconnect",
-    "sdb:remote:disconnect": "ssh -F $npm_config_sshconfig $npm_config_user@$npm_config_host sdb disconnect",
+    "sdb:remote:disconnect": "ssh -F $npm_config_sshconfig $npm_config_user@$npm_config_host $npm_config_path/sdb disconnect",
     "tunnel": "run-p tunnel:wss tunnel:sdb"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "printWidth": 100,
     "singleQuote": true
   },
-  "dependencies": {},
   "devDependencies": {
     "@appium/eslint-config-appium": "6.0.2",
     "@babel/cli": "7.18.9",
@@ -74,6 +73,7 @@
     "@types/teen_process": "1.16.1",
     "@types/ws": "8.5.3",
     "@types/yargs": "17.0.11",
+    "@wdio/types": "7.24.0",
     "appium": "^2.0.0-beta.43",
     "babel-plugin-source-map-support": "2.2.0",
     "cross-env": "7.0.3",

--- a/packages/appium-tizen-tv-driver/lib/cli/helpers.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/helpers.js
@@ -6,44 +6,76 @@ import log from '../logger';
 const TIZEN_BIN_NAME = 'tizen';
 const SDB_BIN_NAME = 'sdb';
 
-const BIN_PATHS = {
+/**
+ * Lookup of path parts by bin name, relative to `TIZEN_HOME` env var
+ */
+const BIN_PATHS = Object.freeze({
   [TIZEN_BIN_NAME]: ['tools', 'ide', 'bin', 'tizen'],
   [SDB_BIN_NAME]: ['tools', 'sdb'],
-};
+});
+
+/**
+ * In-memory cache of known executable paths
+ * @type {Record<string,string>}
+ */
 const bins = {};
 
+/**
+ * Runs external command by "bin name"
+ * @param {KnownBinName} bin
+ * @param {string[]} args
+ */
 async function runCmd(bin, args) {
-  if (!bins[bin]) {
+  if (!(bin in bins)) {
     await setBin(bin);
   }
   log.info(`Running command: ${bins[bin]} ${args.join(' ')}`);
   try {
     return await exec(bins[bin], args);
-  } catch (e) {
-    const stdout = e.stdout.replace(/[\r\n]+/, ' ');
-    const stderr = e.stderr.replace(/[\r\n]+/, ' ');
+  } catch (err) {
+    const e = /** @type {import('teen_process').ExecError} */(err);
+    const stdout = e.stdout.replace(/[\r\n]+/g, ' ');
+    const stderr = e.stderr.replace(/[\r\n]+/g, ' ');
     e.message = `${e.message}. Stdout was: '${stdout}'. Stderr was: '${stderr}'`;
     throw e;
   }
 }
 
+/**
+ * Type guard
+ * @param {any} value
+ * @returns {value is KnownBinName}
+ */
+function isKnownBinName(value) {
+  return value === TIZEN_BIN_NAME || value === SDB_BIN_NAME;
+}
+
+/**
+ * @param {string} name
+ */
 async function setBin(name) {
-  if (!Object.keys(BIN_PATHS).includes(name)) {
+  if (!isKnownBinName(name)) {
     throw new Error(`We don't know how to find the '${name}' binary`);
   }
   log.info(`Attempting to verify location of the '${name}' binary`);
   if (!process.env.TIZEN_HOME) {
-    throw new Error(`TIZEN_HOME env var must be set so that we can find binary`);
+    throw new Error(`TIZEN_HOME env var must be set so that we can find Tizen CLI tools`);
   }
   // TODO check name of binary on windows and update based on platform if necessary
   const bin = path.resolve(process.env.TIZEN_HOME, ...BIN_PATHS[name]);
-  if (!(await fs.exists(bin))) {
+  try {
+    await fs.access(bin, fs.constants.R_OK | fs.constants.X_OK);
+  } catch {
     throw new Error(
       `Tried to find binary at ${bin} but it did not exist or was not ` +
-        `accessible. Please double-check permissions and TIZEN_HOME value`
+        `executable. Please double-check permissions and TIZEN_HOME value`
     );
   }
   bins[name] = bin;
   log.info(`Binary was found at ${bin}`);
 }
 export {runCmd, setBin, TIZEN_BIN_NAME, SDB_BIN_NAME};
+
+/**
+ * @typedef {TIZEN_BIN_NAME|SDB_BIN_NAME} KnownBinName
+ */

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -4,26 +4,41 @@ import {runCmd, SDB_BIN_NAME} from './helpers';
 const DEBUG_PORT_RE = /^(?:.*port:\s)(?<port>\d{1,5})$/;
 const APP_LIST_RE = /^[^']*'(?<name>[^']+)'[^']+'(?<id>[^']+)'.*$/;
 
+/**
+ *
+ * @param {string?} udid
+ * @param {string[]} args
+ */
 async function runSDBCmd(udid, args) {
   const restriction = udid ? ['-s', udid] : [];
   return await runCmd(SDB_BIN_NAME, [...restriction, ...args]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'appPackage' | 'udid'>} caps
+ */
 async function debugApp({appPackage, udid}) {
   log.info(`Starting ${appPackage} in debug mode on ${udid}`);
   const {stdout} = await runSDBCmd(udid, ['shell', '0', 'debug', appPackage]);
   try {
-    const port = stdout.trim().match(DEBUG_PORT_RE).groups.port;
+    const port = stdout.trim().match(DEBUG_PORT_RE)?.groups?.port;
+    if (!port) {
+      throw new Error(`Cannot parse debug port from sdb output`);
+    }
     log.info(`Debug port opened on ${port}`);
     return port;
   } catch (e) {
+    const message = /** @type {import('teen_process').ExecError} */(e);
     throw new Error(
       `Unable to retrieve debugger port from debug start invocation. ` +
-        `Original error: ${e.message}`
+        `Original error: ${message}`
     );
   }
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'>} caps
+ */
 async function listApps({udid}) {
   log.info(`Listing apps installed on '${udid}'`);
   const {stdout} = await runSDBCmd(udid, ['shell', '0', 'applist']);
@@ -32,7 +47,7 @@ async function listApps({udid}) {
     .map((line) => {
       // TODO WIP fix this regex
       const match = line.match(APP_LIST_RE);
-      if (!match) {
+      if (!match?.groups) {
         return false;
       }
       return {appName: match.groups.name, appPackage: match.groups.id};
@@ -42,26 +57,41 @@ async function listApps({udid}) {
   return apps;
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'|'localPort'|'remotePort'>} caps
+ */
 async function forwardPort({udid, localPort, remotePort}) {
   log.info(`Forwarding local TCP port ${localPort} to port ${remotePort} on device ${udid}`);
   await runSDBCmd(udid, ['forward', `tcp:${localPort}`, `tcp:${remotePort}`]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'|'localPort'>} caps
+ */
 async function removeForwardedPort({udid, localPort}) {
   log.info(`Removing port forwarding for device ${udid} and local port ${localPort}`);
   await runSDBCmd(udid, ['forward', '--remove', localPort]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'>} caps
+ */
 async function removeForwardedPorts({udid}) {
   log.info(`Removing all port forwarding for device ${udid}`);
   await runSDBCmd(udid, ['forward', '--remove-all']);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'>} caps
+ */
 async function connectDevice({udid}) {
   log.info(`Connecting device '${udid}' via sdb`);
   await runSDBCmd(null, ['connect', udid]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'udid'>} caps
+ */
 async function disconnectDevice({udid}) {
   log.info(`Disconnecting device '${udid}' via sdb`);
   await runSDBCmd(null, ['disconnect', udid]);
@@ -77,3 +107,7 @@ export {
   disconnectDevice,
   removeForwardedPort,
 };
+
+/**
+ * @typedef {import('../driver').TizenTVDriverCaps} TizenTVDriverCaps
+ */

--- a/packages/appium-tizen-tv-driver/lib/cli/tizen.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/tizen.js
@@ -1,23 +1,39 @@
 import log from '../logger';
 import {runCmd, TIZEN_BIN_NAME} from './helpers';
 
+/**
+ * @param {string[]} args
+ */
 async function runTizenCmd(args) {
   return await runCmd(TIZEN_BIN_NAME, args);
 }
 
+/**
+ * @param {import('type-fest').SetRequired<Pick<TizenTVDriverCaps, 'app'|'udid'>, 'app'>} caps
+ */
 async function tizenInstall({app, udid}) {
   log.info(`Installing tizen app '${app}' on device '${udid}'`);
   return await runTizenCmd(['install', '-n', app, '-s', udid]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'appPackage'|'udid'>} caps
+ */
 async function tizenUninstall({appPackage, udid}) {
   log.info(`Uninstalling tizen app '${appPackage}' on device '${udid}'`);
   return await runTizenCmd(['uninstall', '-p', appPackage, '-s', udid]);
 }
 
+/**
+ * @param {Pick<TizenTVDriverCaps, 'appPackage'|'udid'>} caps
+ */
 async function tizenRun({appPackage, udid}) {
   log.info(`Running tizen app '${appPackage}' on device '${udid}'`);
   return await runTizenCmd(['run', '-p', appPackage, '-s', udid]);
 }
 
 export {runTizenCmd, tizenInstall, tizenUninstall, tizenRun};
+
+/**
+ * @typedef {import('../driver').TizenTVDriverCaps} TizenTVDriverCaps
+ */

--- a/packages/appium-tizen-tv-driver/lib/desired-caps.js
+++ b/packages/appium-tizen-tv-driver/lib/desired-caps.js
@@ -38,6 +38,9 @@ const commonCapConstraints = {
   rcToken: {
     isString: true,
   },
+  resetRcToken: {
+    isBoolean: true,
+  },
   sendKeysStrategy: {
     isString: true,
   },

--- a/packages/appium-tizen-tv-driver/lib/desired-caps.js
+++ b/packages/appium-tizen-tv-driver/lib/desired-caps.js
@@ -1,4 +1,4 @@
-let commonCapConstraints = {
+const commonCapConstraints = {
   platformName: {
     isString: true,
     inclusionCaseInsensitive: ['TizenTV'],
@@ -37,16 +37,16 @@ let commonCapConstraints = {
   },
   rcToken: {
     isString: true,
-    presence: true,
   },
   sendKeysStrategy: {
     isString: true,
   },
+  rcMode: {
+    isString: true,
+    inclusionCaseInsensitive: ['remote', 'js']
+  }
 };
 
-let desiredCapConstraints = {};
+const desiredCapConstraints = {...commonCapConstraints};
 
-Object.assign(desiredCapConstraints, commonCapConstraints);
-
-export default desiredCapConstraints;
-export {commonCapConstraints};
+export {desiredCapConstraints};

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -1,14 +1,14 @@
-import {BaseDriver, DeviceSettings} from 'appium/driver';
+import {BaseDriver} from 'appium/driver';
 import B from 'bluebird';
 import {retryInterval} from 'asyncbox';
-import desiredConstraints from './desired-caps';
+import {desiredCapConstraints} from './desired-caps';
 import {Keys, TizenRemote} from '@headspinio/tizen-remote';
+import {AsyncScripts, SyncScripts} from './scripts';
 
 const RC_TEXT_STRAT = 'rc';
 const PROXY_TEXT_STRAT = 'proxy';
 const SEND_KEYS_STRATS = [RC_TEXT_STRAT, PROXY_TEXT_STRAT];
 
- import _ from 'lodash';
 import {tizenInstall, tizenUninstall, tizenRun} from './cli/tizen';
 import {
   debugApp,
@@ -21,17 +21,28 @@ import Chromedriver from 'appium-chromedriver';
 import getPort from 'get-port';
 import log from './logger';
 import got from 'got';
+import {getKeyData, isRcKeyCode} from './keymap';
 
 const BROWSER_APP_ID = 'org.tizen.browser';
 const DEFAULT_APP_LAUNCH_COOLDOWN = 3000;
+/** @type {Pick<TizenTVDriverCaps, 'appLaunchCooldown' | 'rcMode'>} */
 const DEFAULT_CAPS = {
   appLaunchCooldown: DEFAULT_APP_LAUNCH_COOLDOWN,
+  rcMode: 'js',
 };
+export const RC_MODE_JS = 'js';
+export const RC_MODE_REMOTE = 'remote';
+export const DEFAULT_KEYPRESS_DELAY = 200;
+export const DEFAULT_LONG_KEYPRESS_DELAY = 1000;
 
+/**
+ * @type {import('@appium/types').RouteMatcher[]}
+ */
 const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/appium')],
   ['GET', new RegExp('^/session/[^/]+/appium')],
   ['POST', new RegExp('^/session/[^/]+/element/[^/]+/value')],
+  ['POST', new RegExp('^/session/[^/]+/execute')],
 ];
 
 export const RC_PORT = 8002;
@@ -41,7 +52,50 @@ export const RC_OPTS = {
   name: RC_NAME,
 };
 
+/**
+ * @extends {BaseDriver}
+ */
 class TizenTVDriver extends BaseDriver {
+  static executeMethodMap = Object.freeze({
+    'tizen: pressKey': Object.freeze({
+      command: 'pressKey',
+      params: {required: ['key']},
+    }),
+    'tizen: longPressKey': Object.freeze({
+      command: 'longPressKey',
+      params: {required: ['key'], optional: ['duration']},
+    }),
+  });
+
+  /** @type {TizenRemote|undefined} */
+  #remote;
+
+  /** @type {number[]} */
+  #forwardedPorts;
+
+  /** @type {string[]} */
+  locatorStrategies;
+
+  /** @type {import('@appium/types').Constraints} */
+  #desiredCapConstraints;
+
+  get desiredCapConstraints() {
+    return this.#desiredCapConstraints;;
+  }
+
+  /** @type {boolean} */
+  #jwpProxyActive;
+
+  /**
+   * @type {import('@appium/types').RouteMatcher[]}
+   */
+  #jwpProxyAvoid;
+
+  /**
+   *
+   * @param {any} [opts]
+   * @param {boolean} [shouldValidateCaps]
+   */
   constructor(opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
 
@@ -49,23 +103,51 @@ class TizenTVDriver extends BaseDriver {
       // TODO define tizen locator strategies
     ];
 
-    this.desiredCapConstraints = desiredConstraints;
-    this.jwpProxyActive = false;
-    this.jwpProxyAvoid = _.clone(NO_PROXY);
-    this.settings = new DeviceSettings({});
+    this.#desiredCapConstraints = desiredCapConstraints;
+    this.#jwpProxyActive = false;
+    this.#jwpProxyAvoid = [...NO_PROXY];
 
-    this.forwardedPorts = [];
+    this.#forwardedPorts = [];
   }
 
-  async createSession(...args) {
-    let [sessionId, caps] = await super.createSession(...args);
-    caps = {...DEFAULT_CAPS, ...caps};
-    const shouldPowerCycle = caps.powerCyclePostUrl && caps.fullReset;
+  /**
+   *
+   * @param {any} value
+   * @returns {value is ScriptId}
+   */
+  static isExecuteScript(value) {
+    return value in TizenTVDriver.executeMethodMap;
+  }
 
-    this.setupRCApi(caps);
+  /**
+   * @param {W3CCapabilities} w3cCapabilities1
+   * @param {W3CCapabilities} [w3cCapabilities2]
+   * @param {W3CCapabilities} [w3cCapabilities3]
+   * @param {DriverData[]} [driverData]
+   * @returns {Promise<[string, any]>}
+   */
+  async createSession(w3cCapabilities1, w3cCapabilities2, w3cCapabilities3, driverData) {
+    let [sessionId, capabilities] = /** @type {[string, TizenTVDriverCaps]} */(await super.createSession(
+      w3cCapabilities1,
+      w3cCapabilities2,
+      w3cCapabilities3,
+      driverData
+    ));
+    const caps = {...DEFAULT_CAPS, ...capabilities};
+
+    if (caps.rcMode === 'remote' && !caps.rcToken) {
+      throw new TypeError('Capability "rcToken" required when "rcMode" is "remote"');
+    }
+
+    if (caps.rcMode === RC_MODE_REMOTE) {
+      this.#remote = new TizenRemote(caps.deviceAddress, {
+        ...RC_OPTS,
+        token: caps.rcToken,
+      });
+    }
 
     if (!caps.useOpenDebugPort) {
-      if (shouldPowerCycle) {
+      if (caps.powerCyclePostUrl && caps.fullReset) {
         // first disconnect the device if connected
         await disconnectDevice(caps);
         // power cycle the TV and reconnect sdb
@@ -86,8 +168,9 @@ class TizenTVDriver extends BaseDriver {
         if (!caps.noReset) {
           await tizenUninstall(caps);
         }
-        await tizenInstall(caps);
-      } else if (!shouldPowerCycle) {
+        // XXX this is for typescript
+        await tizenInstall({...caps, app: caps.app});
+      } else if (!(caps.powerCyclePostUrl && caps.fullReset)) {
         // if the user wants to run an existing app, it might already be running and therefore we
         // can't start it. But if we launch another app, it will kill any already-running app. So
         // launch the browser. Of course we don't need to do this if we already power cycled the
@@ -101,18 +184,16 @@ class TizenTVDriver extends BaseDriver {
 
       await this.startChromedriver({
         debuggerPort: localDebugPort,
-        executable: caps.chromedriverExecutable,
+        executable: /** @type {string} */(caps.chromedriverExecutable),
       });
 
       if (!caps.noReset) {
         log.info('Waiting for app launch to take effect');
-        await B.delay(caps.appLaunchCooldown);
-        log.info('Clearing app local storage');
-        await this.executeScript('window.localStorage.clear()');
-        log.info('Reloading page');
-        await this.executeScript('window.location.reload()');
+        await B.delay(/** @type {number} */(caps.appLaunchCooldown));
+        log.info('Clearing app local storage & reloading...');
+        await this.executeChromedriverScript(SyncScripts.reset);
         log.info('Waiting for app launch to take effect again post-reload');
-        await B.delay(caps.appLaunchCooldown);
+        await B.delay(/** @type {number} */(caps.appLaunchCooldown));
       }
       return [sessionId, caps];
     } catch (e) {
@@ -121,6 +202,11 @@ class TizenTVDriver extends BaseDriver {
     }
   }
 
+  /**
+   *
+   * @param {TizenTVDriverCaps} caps
+   * @returns {Promise<number>}
+   */
   async setupDebugger(caps) {
     const remoteDebugPort = caps.useOpenDebugPort || (await debugApp(caps));
     const localDebugPort = await getPort();
@@ -130,17 +216,14 @@ class TizenTVDriver extends BaseDriver {
       remotePort: remoteDebugPort,
       localPort: localDebugPort,
     });
-    this.forwardedPorts.push(localDebugPort);
+    this.#forwardedPorts.push(localDebugPort);
     return localDebugPort;
   }
 
-  setupRCApi({deviceAddress, rcToken}) {
-    this.remote = new TizenRemote(deviceAddress, {
-      ...RC_OPTS,
-      token: rcToken,
-    });
-  }
-
+  /**
+   *
+   * @param {StartChromedriverOptions} opts
+   */
   async startChromedriver({debuggerPort, executable}) {
     this.chromedriver = new Chromedriver({
       port: await getPort(),
@@ -156,13 +239,61 @@ class TizenTVDriver extends BaseDriver {
     });
     this.proxyReqRes = this.chromedriver.proxyReq.bind(this.chromedriver);
     this.proxyCommand = this.chromedriver.jwproxy.proxyCommand.bind(this.chromedriver);
-    this.jwpProxyActive = true;
+    this.#jwpProxyActive = true;
   }
 
-  async executeScript(script) {
+  /**
+   * Given a script of {@linkcode ScriptId} or some arbitrary JS, figure out
+   * which it is and run it.
+   *
+   * @template [TArg=any]
+   * @template [TReturn=any]
+   * @template {import('type-fest').LiteralUnion<ScriptId, string>} [S=string]
+   * @param {S} script
+   * @param {S extends ScriptId ? [Record<string,any>] : TArg[]} args
+   * @returns {Promise<S extends ScriptId ? import('type-fest').AsyncReturnType<ExecuteMethod<S>> : {value: TReturn}>}
+   */
+  async execute(script, args) {
+    if (TizenTVDriver.isExecuteScript(script)) {
+      log.debug(`Calling script "${script}" with arg ${JSON.stringify(args[0])}`);
+      return await this.executeMethod(script, [args[0]]);
+    }
+    return await /** @type {Promise<S extends ScriptId ? import('type-fest').AsyncReturnType<ExecuteMethod<S>> : {value: TReturn}>} */ (
+      this.executeChromedriverScript(script, args)
+    );
+  }
+
+  /**
+   * Execute some arbitrary JS via Chromedriver.
+   * @template [TReturn=any]
+   * @template [TArg=any]
+   * @param {((...args: any[]) => TReturn)|string} script
+   * @param {TArg[]} [args]
+   * @returns {Promise<{value: TReturn}>}
+   */
+  async executeChromedriverScript(script, args = []) {
+    const wrappedScript =
+      typeof script === 'string' ? script : `return (${script}).apply(null, arguments)`;
     return await this.chromedriver.sendCommand('/execute/sync', 'POST', {
-      script,
-      args: [],
+      script: wrappedScript,
+      args,
+    });
+  }
+
+  /**
+   * Execute some arbitrary JS via Chromedriver.
+   * @template [TReturn=any]
+   * @template [TArg=any]
+   * @param {((...args: any[]) => TReturn)|string} script
+   * @param {TArg[]} [args]
+   * @returns {Promise<{value: TReturn}>}
+   */
+  async executeChromedriverAsyncScript(script, args = []) {
+    const wrappedScript =
+      typeof script === 'string' ? script : `return (${script}).apply(null, arguments)`;
+    return await this.chromedriver.sendCommand('/execute/async', 'POST', {
+      script: wrappedScript,
+      args,
     });
   }
 
@@ -170,7 +301,7 @@ class TizenTVDriver extends BaseDriver {
     if (this.chromedriver) {
       log.debug('Terminating app under test');
       try {
-        await this.executeScript('tizen.application.getCurrentApplication().exit()');
+        await this.executeChromedriverScript(SyncScripts.exit);
       } catch (err) {
         log.warn(err);
       }
@@ -180,43 +311,110 @@ class TizenTVDriver extends BaseDriver {
       try {
         await this.chromedriver.stop();
       } catch (err) {
-        log.warn(`Error stopping Chromedriver: ${err.message}`);
+        log.warn(`Error stopping Chromedriver: ${/** @type {Error} */ (err).message}`);
       }
       this.chromedriver = null;
     }
 
-    await this.remote.disconnect();
-    this.remote = null;
+    if (this.#remote) {
+      await this.#remote.disconnect();
+      this.#remote = undefined;
+    }
     await this.cleanUpPorts();
     return await super.deleteSession();
   }
 
   async cleanUpPorts() {
     log.info(`Cleaning up any ports which have been forwarded`);
-    for (const localPort of this.forwardedPorts) {
-      await removeForwardedPort({udid: this.opts.udid, localPort});
+    for (const localPort of this.#forwardedPorts) {
+      await removeForwardedPort({udid: /** @type {string} */(this.opts.udid), localPort});
     }
   }
 
   proxyActive() {
-    return this.jwpProxyActive;
+    return this.#jwpProxyActive;
   }
 
   getProxyAvoidList() {
-    return this.jwpProxyAvoid;
+    return this.#jwpProxyAvoid;
   }
 
   canProxy() {
     return true;
   }
 
-  async pressKeyCode(keycode) {
-    if (!Keys[keycode]) {
-      throw new Error(`Keycode '${keycode}' was not recognized`);
+  /**
+   *
+   * @param {RcKeyCode} rcKeyCode
+   */
+  async pressKey(rcKeyCode) {
+    if (!isRcKeyCode(rcKeyCode)) {
+      throw new TypeError(`Invalid key code: ${rcKeyCode}`);
     }
-    await this.remote.click(keycode);
+    if (this.#remote) {
+      log.debug(`Clicking key ${rcKeyCode} via remote`);
+      return await this.#pressKeyRemote(this.#remote, rcKeyCode);
+    }
+    log.debug(`Clicking key ${rcKeyCode} via Chromedriver`);
+    return await this.#pressKeyJs(rcKeyCode);
   }
 
+  /**
+   * Mimics a keypress via {@linkcode document.dispatchEvent}.
+   * @param {RcKeyCode} rcKeyCode
+   * @param {number} [duration]
+   */
+  async #pressKeyJs(rcKeyCode, duration = DEFAULT_KEYPRESS_DELAY) {
+    const {code, key} = getKeyData(rcKeyCode);
+    if (!code && !key) {
+      throw new Error(`Invalid key code: ${rcKeyCode}`);
+    }
+    return await this.executeChromedriverAsyncScript(AsyncScripts.pressKey, [
+      code,
+      key,
+      duration,
+    ]);
+  }
+
+  /**
+   * Mimics a keypress via Tizen Remote API.
+   * @param {TizenRemote} remote
+   * @param {RcKeyCode} key
+   */
+  async #pressKeyRemote(remote, key) {
+    return await remote.click(key);
+  }
+
+  /**
+   * Mimics a long keypress via Tizen Remote API
+   * @param {TizenRemote} remote
+   * @param {RcKeyCode} rcKeyCode
+   * @param {number} [duration]
+   */
+  async #longPressKeyRemote(remote, rcKeyCode, duration = 1000) {
+    await remote.press(rcKeyCode);
+    await B.delay(duration);
+    await remote.release(rcKeyCode);
+  }
+
+  /**
+   *
+   * @param {RcKeyCode} key
+   * @param {number} [duration]
+   */
+  async longPressKey(key, duration = DEFAULT_LONG_KEYPRESS_DELAY) {
+    if (this.#remote) {
+      return await this.#longPressKeyRemote(this.#remote, key, duration);
+    }
+    return await this.#pressKeyJs(key, duration);
+  }
+
+  /**
+   * Sets the value of a text input box
+   * @param {string} text
+   * @param {string} elId
+   * @returns
+   */
   async setValue(text, elId) {
     if (!SEND_KEYS_STRATS.includes(this.opts.sendKeysStrategy)) {
       throw new Error(
@@ -227,20 +425,73 @@ class TizenTVDriver extends BaseDriver {
     }
 
     if (this.opts.sendKeysStrategy === RC_TEXT_STRAT) {
-      if (_.isArray(text)) {
+      if (Array.isArray(text)) {
         text = text.join('');
       }
       await B.delay(800);
-      await this.remote.text(text);
-      await this.pressKeyCode(Keys.ENTER);
+      if (this.#remote) {
+        await this.#remote.text(text);
+      }
+      await this.pressKey(Keys.ENTER);
       await B.delay(800);
       return;
     }
 
     return await this.proxyCommand(`/element/${elId}/value`, 'POST', {text});
   }
-
 }
 
-export {TizenTVDriver};
+export {TizenTVDriver, Keys};
 export default TizenTVDriver;
+
+/**
+ * @typedef {keyof TizenTVDriverExecuteMethodMap} ScriptId
+ * @typedef {BaseTizenTVDriverCaps & Capabilities} TizenTVDriverCaps
+ * @typedef {import('@appium/types').AppiumW3CCapabilities & NamespacedObject<BaseTizenTVDriverCaps>} TizenTVDriverW3CCaps
+ * @typedef {typeof RC_MODE_JS | typeof RC_MODE_REMOTE} RcMode
+ * @typedef {typeof TizenTVDriver.executeMethodMap} TizenTVDriverExecuteMethodMap
+ */
+
+/**
+ * @typedef StartChromedriverOptions
+ * @property {string} executable
+ * @property {number} debuggerPort
+ */
+
+/**
+ * Lookup a method by its script ID.
+ * @template {ScriptId} S
+ * @typedef {TizenTVDriver[TizenTVDriverExecuteMethodMap[S]['command']]} ExecuteMethod
+ */
+
+/**
+ * {@linkcode TizenTVDriver}-specific caps
+ * @typedef BaseTizenTVDriverCaps
+ * @property {string} chromedriverExecutable
+ * @property {string} udid
+ * @property {string} appPackage
+ * @property {string} deviceName
+ * @property {string} deviceAddress
+ * @property {boolean} [isDeviceApiSsl]
+ * @property {number} [useOpenDebugPort]
+ * @property {string} [powerCyclePostUrl]
+ * @property {string} [rcToken]
+ * @property {string} [sendKeysStrategy]
+ * @property {RcMode} [rcMode]
+ * @property {number} [appLaunchCooldown]
+ */
+
+/**
+ * Given object `T` and namespace `NS`, return a new object with keys namespaced by `${NS}:`.
+ * @template {Record<string,any>} T
+ * @template {string} [NS='appium']
+ * @typedef {{[K in keyof T as `${NS}:${K & string}`]: T[K]}} NamespacedObject
+ */
+
+
+ /**
+ * @typedef {import('@appium/types').Capabilities} Capabilities
+ * @typedef {import('@headspinio/tizen-remote').RcKeyCode} RcKeyCode
+ * @typedef {import('@appium/types').DriverData} DriverData
+ * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
+ */

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -247,7 +247,7 @@ class TizenTVDriver extends BaseDriver {
    * which it is and run it.
    *
    * @template [TArg=any]
-   * @template [TReturn=any]
+   * @template [TReturn=unknown]
    * @template {import('type-fest').LiteralUnion<ScriptId, string>} [S=string]
    * @param {S} script
    * @param {S extends ScriptId ? [Record<string,any>] : TArg[]} args
@@ -272,9 +272,22 @@ class TizenTVDriver extends BaseDriver {
    * @returns {Promise<{value: TReturn}>}
    */
   async executeChromedriverScript(script, args = []) {
+    return await this.#executeChromedriverScript('/execute/sync', script, args);
+  }
+
+  /**
+   * Execute some arbitrary JS via Chromedriver.
+   * @template [TReturn=unknown]
+   * @template [TArg=any]
+   * @param {string} endpointPath - Relative path of the endpoint URL
+   * @param {((...args: any[]) => TReturn)|string} script
+   * @param {TArg[]} [args]
+   * @returns {Promise<{value: TReturn}>}
+   */
+  async #executeChromedriverScript(endpointPath, script, args = []) {
     const wrappedScript =
       typeof script === 'string' ? script : `return (${script}).apply(null, arguments)`;
-    return await this.chromedriver.sendCommand('/execute/sync', 'POST', {
+    return await this.chromedriver.sendCommand(endpointPath, 'POST', {
       script: wrappedScript,
       args,
     });
@@ -282,19 +295,14 @@ class TizenTVDriver extends BaseDriver {
 
   /**
    * Execute some arbitrary JS via Chromedriver.
-   * @template [TReturn=any]
+   * @template [TReturn=unknown]
    * @template [TArg=any]
    * @param {((...args: any[]) => TReturn)|string} script
    * @param {TArg[]} [args]
    * @returns {Promise<{value: TReturn}>}
    */
   async executeChromedriverAsyncScript(script, args = []) {
-    const wrappedScript =
-      typeof script === 'string' ? script : `return (${script}).apply(null, arguments)`;
-    return await this.chromedriver.sendCommand('/execute/async', 'POST', {
-      script: wrappedScript,
-      args,
-    });
+    return await this.#executeChromedriverScript('/execute/async', script, args);
   }
 
   async deleteSession() {

--- a/packages/appium-tizen-tv-driver/lib/global.d.ts
+++ b/packages/appium-tizen-tv-driver/lib/global.d.ts
@@ -1,0 +1,2 @@
+declare module 'asyncbox';
+declare module 'appium-chromedriver';

--- a/packages/appium-tizen-tv-driver/lib/keymap.js
+++ b/packages/appium-tizen-tv-driver/lib/keymap.js
@@ -1,0 +1,311 @@
+import keycode from 'keycode';
+import {Keys} from '@headspinio/tizen-remote';
+
+/**
+ * This thing maps an Rc Key Code to a UTF-8 key code.
+ * @module
+ *
+ */
+
+/**
+ * Map of keyboard keys to UTF-8 key codes.  Probably only usedful for testing
+ * keyboard (non-RC) interaction.
+ */
+const Utf8Keys = Object.freeze({
+  NULL: '\uE000',
+  CANCEL: '\uE001',
+  HELP: '\uE002',
+  BACKSPACE: '\uE003',
+  TAB: '\uE004',
+  CLEAR: '\uE005',
+  RETURN: '\uE006',
+  ENTER: '\uE007',
+  SHIFT: '\uE008',
+  CONTROL: '\uE009',
+  ALT: '\uE00a',
+  PAUSE: '\uE00b',
+  ESCAPE: '\uE00c',
+  SPACE: '\uE00d',
+  PAGE_UP: '\uE00e',
+  PAGE_DOWN: '\uE00f',
+  END: '\uE010',
+  HOME: '\uE011',
+  LEFT: '\uE012',
+  UP: '\uE013',
+  RIGHT: '\uE014',
+  DOWN: '\uE015',
+  INSERT: '\uE016',
+  DELETE: '\uE017',
+  SEMICOLON: '\uE018',
+  EQUALS: '\uE019',
+  NUMPAD0: '\uE01a',
+  NUMPAD1: '\uE01b',
+  NUMPAD2: '\uE01c',
+  NUMPAD3: '\uE01d',
+  NUMPAD4: '\uE01e',
+  NUMPAD5: '\uE01f',
+  NUMPAD6: '\uE020',
+  NUMPAD7: '\uE021',
+  NUMPAD8: '\uE022',
+  NUMPAD9: '\uE023',
+  MULTIPLY: '\uE024',
+  ADD: '\uE025',
+  SEPARATOR: '\uE026',
+  SUBTRACT: '\uE027',
+  DECIMAL: '\uE028',
+  DIVIDE: '\uE029',
+  F1: '\uE031',
+  F2: '\uE032',
+  F3: '\uE033',
+  F4: '\uE034',
+  F5: '\uE035',
+  F6: '\uE036',
+  F7: '\uE037',
+  F8: '\uE038',
+  F9: '\uE039',
+  F10: '\uE03a',
+  F11: '\uE03b',
+  F12: '\uE03c',
+  META: '\uE03d',
+  /**
+   * ikr?
+   * @see https://en.wikipedia.org/wiki/Language_input_keys
+   */
+  ZENKAKUHANKAKU: '\uE040',
+  R_SHIFT: '\uE050',
+  R_CONTROL: '\uE051',
+  R_ALT: '\uE052',
+  R_META: '\uE053',
+  R_PAGEUP: '\uE054',
+  R_PAGEDOWN: '\uE055',
+  R_END: '\uE056',
+  R_HOME: '\uE057',
+  R_ARROWLEFT: '\uE058',
+  R_ARROWUP: '\uE059',
+  R_ARROWRIGHT: '\uE05A',
+  R_ARROWDOWN: '\uE05B',
+  R_INSERT: '\uE05C',
+  R_DELETE: '\uE05D',
+});
+
+
+/**
+ * Name/code pairing of remote control keys supported by the Tizen JS API
+ * via `tizen.tvinputdevice`.
+ *
+ */
+ const JsKeyCodes = Object.freeze({
+  0: 48,
+  1: 49,
+  2: 50,
+  3: 51,
+  4: 52,
+  5: 53,
+  6: 54,
+  7: 55,
+  8: 56,
+  9: 57,
+  VolumeUp: 447,
+  VolumeDown: 448,
+  VolumeMute: 449,
+  ChannelUp: 427,
+  ChannelDown: 428,
+  ColorF0Red: 403,
+  ColorF1Green: 404,
+  ColorF2Yellow: 405,
+  ColorF3Blue: 406,
+  Menu: 10133,
+  Tools: 10135,
+  Info: 457,
+  Exit: 10182,
+  Search: 10225,
+  Guide: 458,
+  MediaRewind: 412,
+  MediaPause: 19,
+  MediaFastForward: 417,
+  MediaRecord: 416,
+  MediaPlay: 415,
+  MediaStop: 413,
+  MediaPlayPause: 10252, // unknown mapping
+  MediaTrackPrevious: 10232, // unknown mapping
+  MediaTrackNext: 10233, // unknown mapping
+  Source: 10072,
+  PictureSize: 10140,
+  PreviousChannel: 10190,
+  ChannelList: 10073,
+  'E-Manual': 10146,
+  MTS: 10195,
+  '3D': 10199, // unknown mapping
+  Soccer: 10228, // unknown mapping
+  Caption: 10221,
+  Teletext: 10200,
+  Extra: 10253, // unknown mapping
+  Minus: 189, // unknown mapping
+
+  // "mandatory keys"
+  ArrowUp: 38,
+  ArrowRight: 39,
+  ArrowLeft: 37,
+  ArrowDown: 40,
+  Enter: 13,
+  Back: 10009,
+});
+
+/**
+ * Set of {@linkcode RcKeyCode} values
+ */
+const RcKeyCodes = Object.freeze(new Set(Object.values(Keys)));
+
+/**
+ * Mapping of {@linkcode RcKeyCode}s to JS key code names (`key`s).
+ */
+const RcToJsKeyCodes = Object.freeze(
+  /** @type {RcToJsKeyMap} */
+   {
+    KEY_0: '0',
+    KEY_1: '1',
+    KEY_2: '2',
+    KEY_3: '3',
+    KEY_4: '4',
+    KEY_5: '5',
+    KEY_6: '6',
+    KEY_7: '7',
+    KEY_8: '8',
+    KEY_9: '9',
+    KEY_VOLDOWN: 'VolumeDown',
+    KEY_VOLUP: 'VolumeUp',
+    KEY_MUTE: 'VolumeMute',
+    KEY_UP: 'ArrowUp',
+    KEY_DOWN: 'ArrowDown',
+    KEY_LEFT: 'ArrowLeft',
+    KEY_RIGHT: 'ArrowRight',
+    KEY_CHUP: 'ChannelUp',
+    KEY_CHDOWN: 'ChannelDown',
+    KEY_RED: 'ColorF0Red',
+    KEY_GREEN: 'ColorF1Green',
+    KEY_YELLOW: 'ColorF2Yellow',
+    KEY_BLUE: 'ColorF3Blue',
+    KEY_MENU: 'Menu',
+    KEY_TOOLS: 'Tools',
+    KEY_INFO: 'Info',
+    KEY_EXIT: 'Exit',
+    KEY_ENTER: 'Enter',
+    KEY_RETURN: 'Back',
+    KEY_GUIDE: 'Guide',
+    KEY_REWIND: 'MediaRewind',
+    KEY_PAUSE: 'MediaPause',
+    KEY_FF: 'MediaFastForward',
+    KEY_REC: 'MediaRecord',
+    KEY_PLAY: 'MediaPlay',
+    KEY_STOP: 'MediaStop',
+    KEY_SOURCE: 'Source',
+    KEY_PICTURE_SIZE: 'PictureSize',
+    KEY_PRECH: 'PreviousChannel',
+    KEY_CH_LIST: 'ChannelList',
+    KEY_HELP: 'E-Manual', // ??
+    KEY_MTS: 'MTS',
+    KEY_CAPTION: 'Caption',
+    KEY_TTX_MIX: 'Teletext', // ??
+  }
+);
+
+/**
+ * Returns the JS key code (`code`) for a given remote control key code (if one is found).
+ *
+ * Not all `RcKeyCode`s have a corresponding JS key code.
+ * @param {RcKeyCode} rcKeyCode
+ * @returns {number|undefined}
+ */
+export function toJsKeyCode(rcKeyCode) {
+  return hasJsKeyCode(rcKeyCode) ? JsKeyCodes[RcToJsKeyCodes[rcKeyCode]] : undefined;
+}
+
+/**
+ * Returns the JS key (`key`) for a given remote control key code (if one is found).
+ *
+ * Not all `RcKeyCode`s have a corresponding JS key code.
+ * @param {RcKeyCode} rcKeyCode
+ * @returns {string|undefined}
+ */
+export function toJsKey(rcKeyCode) {
+  return hasJsKeyCode(rcKeyCode) ? RcToJsKeyCodes[rcKeyCode] : undefined;
+}
+
+/**
+ * Type guard; checks if an `RcKeyCode` is also a {@linkcode RcJsKeyCode}.
+ * @param {RcKeyCode} rcKeyCode
+ * @returns {rcKeyCode is RcJsKeyCode}
+ */
+export function hasJsKeyCode(rcKeyCode) {
+  return rcKeyCode in RcToJsKeyCodes;
+}
+
+/**
+ * Type guard. Returns `true` if `name` is a valid `RcKeyCode`
+ * @param {any} value
+ * @returns {value is RcKeyCode}
+ */
+export function isRcKeyCode(value) {
+  return RcKeyCodes.has(value);
+}
+
+/**
+ * Type guard. Returns `true` if `value` is a key of {@linkcode Utf8Keys}.
+ * @param {any} value
+ * @returns {value is keyof typeof Utf8Keys}
+ */
+export function isUtf8Key(value) {
+  return value in Utf8Keys;
+}
+
+/**
+ * Given an {@linkcode RcKeyCode} or any `string`, returns a key which can be used in a {@linkcode KeyboardEvent}.  `keyCode` could thus be a single character, a UTF-8 character, or   a {@linkcode Utf8Key}.
+ * @param {RcKeyCode|string} keyCode
+ * @returns {KeyData}
+ */
+export function getKeyData(keyCode) {
+  /** @type {KeyData} */
+  const data = {};
+  if (isRcKeyCode(keyCode)) {
+    // if this is an RcKeyCode, we want to get the corresponding JS key code and key.
+    // the names (keys) of these and their codes are determined by the platform.
+    const code = toJsKeyCode(keyCode);
+    if (code) {
+      data.code = code;
+    }
+    const key = toJsKey(keyCode);
+    if (key) {
+      data.key = key;
+    }
+  } else {
+    // if just some string,
+    if (isUtf8Key(keyCode)) {
+      data.key = Utf8Keys[keyCode];
+    }
+    data.code = keycode(keyCode);
+  }
+  data.key = data.key ?? keyCode;
+  return data;
+}
+
+
+/**
+ * A key in the {@linkcode JsKeyCodes} mapping
+ * @typedef {keyof typeof JsKeyCodes} JsKeyCode
+ */
+
+/**
+ * An {@linkcode RcKeyCode} which has a corresponding JS key code.
+ * @typedef {keyof typeof RcToJsKeyCodes} RcJsKeyCode
+ */
+
+/**
+ * @typedef {import('@headspinio/tizen-remote').RcKeyCode} RcKeyCode
+ */
+
+/**
+ * Data for a `KeyboardEvent` constructor; passed to Tizen app via Chromedriver;
+ * @typedef KeyData
+ * @property {number} [code]
+ * @property {string} [key]
+ */

--- a/packages/appium-tizen-tv-driver/lib/scripts.js
+++ b/packages/appium-tizen-tv-driver/lib/scripts.js
@@ -1,0 +1,52 @@
+/**
+ * These are scripts which are sent to the browser via an `/execute/<async|sync>` command.
+ * @module
+ */
+
+/**
+ * All functions must have a final parameter which is a {@linkcode AsyncCallback}.
+ *
+ * This is not expressible dynamically in TS, so I didn't do it
+ */
+export const AsyncScripts = Object.freeze({
+  /**
+   * @param {number|string} code
+   * @param {string} key
+   * @param {number} duration
+   * @param {AsyncCallback} done
+   * @returns {void}
+   */
+  pressKey: (code, key, duration, done) => {
+    document.dispatchEvent(new KeyboardEvent('keydown', {code: String(code), key}));
+    setTimeout(() => {
+      document.dispatchEvent(new KeyboardEvent('keyup', {code: String(code), key}));
+      done(null);
+    }, duration);
+  },
+});
+
+/**
+ * These are all synchronous
+ */
+export const SyncScripts = Object.freeze({
+  exit: () => {
+    // @ts-expect-error
+    window.tizen.application.getCurrentApplication().exit();
+  },
+  reset: () => {
+    window.localStorage.clear();
+    window.location.reload();
+  },
+});
+
+/**
+ * The callback function passed to the script executed via `execute/async`.
+ *
+ * If this function was called without a parameter, it would respond still with `null` to the requester,
+ * so we demand `null` at minimum here for consistency.
+ *
+ * @template [T=null]
+ * @callback AsyncCallback
+ * @param {T extends undefined ? never : T} result
+ * @returns {void}
+ */

--- a/packages/appium-tizen-tv-driver/lib/server.js
+++ b/packages/appium-tizen-tv-driver/lib/server.js
@@ -1,12 +1,25 @@
 import log from './logger';
-import {routeConfiguringFunction, server as baseServer} from 'appium-base-driver';
+import {routeConfiguringFunction, server as baseServer} from 'appium/driver';
 import TizenTVDriver from './driver';
 
+/**
+ *
+ * @param {number} port
+ * @param {string} host
+ * @returns {Promise<import('@appium/types').AppiumServer>}
+ */
 async function startServer(port, host) {
   let tizenTVDriver = new TizenTVDriver();
   log.debug('Driver ready!');
   let router = routeConfiguringFunction(tizenTVDriver);
-  let server = await baseServer(router, port, host);
+  let server = await baseServer(
+    // @ts-expect-error
+    {
+      routeConfiguringFunction: router,
+      port,
+      hostname: host,
+    }
+  );
   log.info(`TizenTVDriver server listening on http://${host}:${port}`);
   return server;
 }

--- a/packages/appium-tizen-tv-driver/package.json
+++ b/packages/appium-tizen-tv-driver/package.json
@@ -42,6 +42,7 @@
     "bluebird": "3.4.7",
     "get-port": "5.1.1",
     "got": "11.8.2",
+    "keycode": "2.2.1",
     "lodash": "4.17.9",
     "source-map-support": "0.5.9",
     "teen_process": "1.9.0",

--- a/packages/appium-tizen-tv-driver/test/e2e/browser.d.ts
+++ b/packages/appium-tizen-tv-driver/test/e2e/browser.d.ts
@@ -1,0 +1,12 @@
+import type { Browser, RemoteOptions } from "webdriverio";
+import {RcKeyCode} from '@headspinio/tizen-remote';
+
+/**
+ * An async webdriverio browser with custom command(s)
+ */
+
+export interface TizenBrowser extends Browser<'async'> {
+  pressKey(key: RcKeyCode): Promise<unknown>;
+}
+
+export function tizenBrowser(opts: RemoteOptions): Promise<TizenBrowser>;

--- a/packages/appium-tizen-tv-driver/test/e2e/browser.d.ts
+++ b/packages/appium-tizen-tv-driver/test/e2e/browser.d.ts
@@ -7,6 +7,7 @@ import {RcKeyCode} from '@headspinio/tizen-remote';
 
 export interface TizenBrowser extends Browser<'async'> {
   pressKey(key: RcKeyCode): Promise<unknown>;
+  longPressKey(key: RcKeyCode, duration?: number): Promise<unknown>;
 }
 
 export function tizenBrowser(opts: RemoteOptions): Promise<TizenBrowser>;

--- a/packages/appium-tizen-tv-driver/test/e2e/browser.js
+++ b/packages/appium-tizen-tv-driver/test/e2e/browser.js
@@ -8,9 +8,17 @@ export async function tizenBrowser(opts) {
   browser.addCommand(
     'pressKey',
     /**
-     * @param {string} key
+     * @param {import('@headspinio/tizen-remote').RcKeyCode} key
      */
     async (key) => await browser.execute('tizen: pressKey', {key})
+  );
+  browser.addCommand(
+    'longPressKey',
+    /**
+     * @param {import('@headspinio/tizen-remote').RcKeyCode} key
+     * @param {number} [duration]
+     */
+    async (key, duration) => await browser.execute('tizen: longPressKey', {key, duration})
   );
   return browser;
 }

--- a/packages/appium-tizen-tv-driver/test/e2e/browser.js
+++ b/packages/appium-tizen-tv-driver/test/e2e/browser.js
@@ -1,0 +1,16 @@
+import {remote} from 'webdriverio';
+
+/**
+ * @type {import('./browser').tizenBrowser}
+ */
+export async function tizenBrowser(opts) {
+  const browser = await remote(opts);
+  browser.addCommand(
+    'pressKey',
+    /**
+     * @param {string} key
+     */
+    async (key) => await browser.execute('tizen: pressKey', {key})
+  );
+  return browser;
+}

--- a/packages/appium-tizen-tv-driver/test/e2e/driver.e2e.spec.js
+++ b/packages/appium-tizen-tv-driver/test/e2e/driver.e2e.spec.js
@@ -1,70 +1,100 @@
 import {Env} from '@humanwhocodes/env';
-import {server as baseServer, routeConfiguringFunction} from 'appium/driver';
-import TizenTVDriver from '../../lib/driver';
+import {Keys} from '@headspinio/tizen-remote';
+import {startServer, TEST_HOST} from '../helpers';
 import getPort from 'get-port';
-import {remote as wdio} from 'webdriverio';
+import unexpected from 'unexpected';
+import {tizenBrowser} from './browser';
+import {getChromedriverBinaryPath} from 'appium-chromedriver/build/lib/utils';
+const expect = unexpected.clone();
 
-const env = new Env();
-
-const TEST_HOST = '127.0.0.1';
-const DEVICE = env.get('TEST_APPIUM_TIZEN_DEVICE', `${TEST_HOST}:26101`);
-const CAPS = {
-  'appium:udid': DEVICE,
-  'appium:deviceName': DEVICE,
-  platformName: 'TizenTV',
-  'appium:appPackage': env.require('TEST_APPIUM_TIZEN_APPID'),
-  'appium:automationName': 'TizenTV',
-  'appium:appLaunchCooldown': 5000,
-  'appium:rcToken': env.require('TEST_APPIUM_TIZEN_TOKEN'),
-  'appium:sendKeysStrategy': 'rc',
-  'appium:deviceAddress': DEVICE.split(':')[0],
-  'appium:chromedriverExecutable': env.require('TEST_APPIUM_TIZEN_CHROMEDRIVER'),
-};
-
-async function startServer(port, hostname = TEST_HOST) {
-  const d = new TizenTVDriver();
-  const server = await baseServer({
-    routeConfiguringFunction: routeConfiguringFunction(d),
-    port,
-    hostname,
-  });
-  return server;
+const SAMPLE_APP_ID = 'tNQ5t7rV07.sample';
+const DEFAULT_DEVICE = `${TEST_HOST}:26101`;
+/**
+ *
+ * @param {import('./browser').TizenBrowser} driver
+ * @param {import('@appium/types').AppiumServer} server
+ */
+async function cleanup(driver, server) {
+  try {
+    await driver.deleteSession();
+  } catch {}
+  try {
+    await server.close();
+  } catch {}
 }
 
 describe('TizenTVDriver', function () {
+
+  const env = new Env();
+
   /** @type {number} */
-  let port;
+  let appiumServerPort;
   /**
    * @type {import('@appium/types').AppiumServer}
    */
   let server;
   /**
-   * @type {import('webdriverio').Browser<'async'>}
+   * @type {import('./browser').TizenBrowser}
    */
   let driver;
 
+  /** @type {string} */
+  let device;
+
+  /** @type {import('../../lib/driver').TizenTVDriverW3CCaps} */
+  let caps;
+
+  process.on('SIGHUP', async () => {
+    await cleanup(driver, server);
+  });
+
   before(async function () {
-    this.timeout(0);
-    port = await getPort();
-    server = await startServer(port);
-    driver = await wdio({
+    device = env.get('TEST_APPIUM_TIZEN_DEVICE', DEFAULT_DEVICE);
+    caps = {
+      'appium:udid': device,
+      'appium:deviceName': device,
+      platformName: 'TizenTV',
+      'appium:appPackage': env.get('TEST_APPIUM_TIZEN_APPID', SAMPLE_APP_ID),
+      'appium:automationName': 'TizenTV',
+      'appium:appLaunchCooldown': 5000,
+      'appium:rcToken': env.get('TEST_APPIUM_TIZEN_TOKEN'),
+      'appium:sendKeysStrategy': 'rc',
+      'appium:deviceAddress': device.split(':')[0],
+      'appium:chromedriverExecutable': env.get('TEST_APPIUM_TIZEN_CHROMEDRIVER'),
+    };
+
+    if (!caps['appium:chromedriverExecutable']) {
+      caps['appium:chromedriverExecutable'] = await getChromedriverBinaryPath();
+    }
+
+    this.timeout('40s');
+    appiumServerPort = await getPort();
+    server = await startServer(appiumServerPort);
+    driver = await tizenBrowser({
       hostname: TEST_HOST,
-      port,
+      port: appiumServerPort,
       connectionRetryCount: 0,
       logLevel: 'debug',
-      capabilities: CAPS,
+      capabilities: caps,
     });
   });
 
   after(async function () {
-    this.timeout(0);
-    try {
-      await driver.deleteSession();
-    } catch {}
-    try {
-      await server.close();
-    } catch {}
+    this.timeout('20s');
+    await cleanup(driver, server);
   });
 
-  it('should login', async function () {});
+  it('should run some javascript', async function() {
+    const header = await driver.$('#header');
+    expect(await header.getText(), 'to equal', 'Initialized');
+  });
+
+  it('should press a button on the remote control', async function () {
+    await driver.pressKey(Keys.ENTER);
+    const name = await driver.$('#rc-button-name').getValue();
+    const code = await driver.$('#rc-button-code').getValue();
+    expect(name, 'to equal', 'Enter');
+    expect(code, 'to equal', '13');
+  });
 });
+

--- a/packages/appium-tizen-tv-driver/test/e2e/driver.e2e.spec.js
+++ b/packages/appium-tizen-tv-driver/test/e2e/driver.e2e.spec.js
@@ -5,6 +5,7 @@ import getPort from 'get-port';
 import unexpected from 'unexpected';
 import {tizenBrowser} from './browser';
 import {getChromedriverBinaryPath} from 'appium-chromedriver/build/lib/utils';
+import {RC_MODE_JS, PLATFORM_NAME, RC_MODE_REMOTE} from '../../lib/driver';
 const expect = unexpected.clone();
 
 const SAMPLE_APP_ID = 'tNQ5t7rV07.sample';
@@ -24,6 +25,23 @@ async function cleanup(driver, server) {
 }
 
 describe('TizenTVDriver', function () {
+  /**
+   * ***VERY IMPORTANT***: if we cancel a test we **MUST MUST MUST** run cleanup
+   * or the device will get stuck in the app and we'll have to either restart it
+   * or reinstall the app.
+   * @param {import('./browser').TizenBrowser} driver
+   * @param {import('@appium/types').AppiumServer} server
+   */
+  function listenForInterrupts(driver, server) {
+    process.removeAllListeners('SIGHUP').removeAllListeners('SIGINT');
+    process
+      .once('SIGHUP', async () => {
+        await cleanup(driver, server);
+      })
+      .once('SIGINT', async () => {
+        await cleanup(driver, server);
+      });
+  }
 
   const env = new Env();
 
@@ -42,59 +60,128 @@ describe('TizenTVDriver', function () {
   let device;
 
   /** @type {import('../../lib/driver').TizenTVDriverW3CCaps} */
-  let caps;
+  let capabilities;
 
-  process.on('SIGHUP', async () => {
-    await cleanup(driver, server);
-  });
+  /** @type {import('../../lib/driver').TizenTVDriverW3CCaps} */
+  let baseCaps;
 
   before(async function () {
     device = env.get('TEST_APPIUM_TIZEN_DEVICE', DEFAULT_DEVICE);
-    caps = {
+    baseCaps = {
       'appium:udid': device,
       'appium:deviceName': device,
-      platformName: 'TizenTV',
+      platformName: PLATFORM_NAME,
       'appium:appPackage': env.get('TEST_APPIUM_TIZEN_APPID', SAMPLE_APP_ID),
       'appium:automationName': 'TizenTV',
       'appium:appLaunchCooldown': 5000,
-      'appium:rcToken': env.get('TEST_APPIUM_TIZEN_TOKEN'),
       'appium:sendKeysStrategy': 'rc',
       'appium:deviceAddress': device.split(':')[0],
       'appium:chromedriverExecutable': env.get('TEST_APPIUM_TIZEN_CHROMEDRIVER'),
     };
 
-    if (!caps['appium:chromedriverExecutable']) {
-      caps['appium:chromedriverExecutable'] = await getChromedriverBinaryPath();
+    if (!baseCaps['appium:chromedriverExecutable']) {
+      baseCaps['appium:chromedriverExecutable'] = await getChromedriverBinaryPath();
     }
+  });
 
-    this.timeout('40s');
-    appiumServerPort = await getPort();
-    server = await startServer(appiumServerPort);
-    driver = await tizenBrowser({
-      hostname: TEST_HOST,
-      port: appiumServerPort,
-      connectionRetryCount: 0,
-      logLevel: 'debug',
-      capabilities: caps,
+  describe('when run in "js" mode', function () {
+    before(async function () {
+      capabilities = {...baseCaps, 'appium:rcMode': RC_MODE_JS};
+      appiumServerPort = await getPort();
+      server = await startServer(appiumServerPort);
+      driver = await tizenBrowser({
+        hostname: TEST_HOST,
+        port: appiumServerPort,
+        connectionRetryCount: 0,
+        logLevel: 'debug',
+        capabilities,
+      });
+      listenForInterrupts(driver, server);
+    });
+
+    after(async function () {
+      this.timeout('20s');
+      await cleanup(driver, server);
+    });
+
+    it('should run some javascript', async function () {
+      const header = await driver.$('#header');
+      expect(await header.getText(), 'to equal', 'Initialized');
+    });
+
+    it('should press a button on the remote control', async function () {
+      await driver.pressKey(Keys.ENTER);
+      const name = await driver.$('#rc-button-name').getValue();
+      const code = await driver.$('#rc-button-code').getValue();
+      const duration = await driver.$('#event-duration').getText();
+      expect(code, 'to equal', '13');
+      expect(name, 'to equal', 'Enter');
+      expect(Number(duration), 'to be less than', 500);
+    });
+
+    it('should "long press" a button on the remote control', async function () {
+      await driver.longPressKey(Keys.ENTER);
+      const name = await driver.$('#rc-button-name').getValue();
+      const code = await driver.$('#rc-button-code').getValue();
+      const duration = await driver.$('#event-duration').getText();
+      expect(code, 'to equal', '13');
+      expect(name, 'to equal', 'Enter');
+      expect(Number(duration), 'to be greater than or equal to', 500);
     });
   });
 
-  after(async function () {
-    this.timeout('20s');
-    await cleanup(driver, server);
-  });
+  describe('when run in "remote" mode', function () {
+    before(async function () {
+      // this can take awhile as we may need to get a new token.
 
-  it('should run some javascript', async function() {
-    const header = await driver.$('#header');
-    expect(await header.getText(), 'to equal', 'Initialized');
-  });
+      this.timeout('60s');
+      capabilities = {
+        ...baseCaps,
+        'appium:rcMode': RC_MODE_REMOTE,
+        'appium:rcToken': env.get('TEST_APPIUM_TIZEN_RC_TOKEN'),
+        'appium:resetRcToken': true,
+      };
 
-  it('should press a button on the remote control', async function () {
-    await driver.pressKey(Keys.ENTER);
-    const name = await driver.$('#rc-button-name').getValue();
-    const code = await driver.$('#rc-button-code').getValue();
-    expect(name, 'to equal', 'Enter');
-    expect(code, 'to equal', '13');
+      appiumServerPort = await getPort();
+      server = await startServer(appiumServerPort);
+      driver = await tizenBrowser({
+        hostname: TEST_HOST,
+        port: appiumServerPort,
+        connectionRetryCount: 0,
+        logLevel: 'debug',
+        capabilities,
+      });
+      listenForInterrupts(driver, server);
+    });
+
+    after(async function () {
+      this.timeout('20s');
+      await cleanup(driver, server);
+    });
+
+    it('should run some javascript', async function () {
+      const header = await driver.$('#header');
+      expect(await header.getText(), 'to equal', 'Initialized');
+    });
+
+    it('should press a button on the remote control', async function () {
+      await driver.pressKey(Keys.ENTER);
+      const name = await driver.$('#rc-button-name').getValue();
+      const code = await driver.$('#rc-button-code').getValue();
+      const duration = await driver.$('#event-duration').getText();
+      expect(code, 'to equal', 'Enter'); // !!!
+      expect(name, 'to equal', 'Enter');
+      expect(Number(duration), 'to be less than', 500);
+    });
+
+    it('should "long press" a button on the remote control', async function () {
+          await driver.longPressKey(Keys.ENTER);
+      const name = await driver.$('#rc-button-name').getValue();
+      const code = await driver.$('#rc-button-code').getValue();
+      const duration = await driver.$('#event-duration').getText();
+      expect(code, 'to equal', 'Enter'); // !!!
+      expect(name, 'to equal', 'Enter');
+      expect(Number(duration), 'to be greater than or equal to', 500);
+    });
   });
 });
-

--- a/packages/appium-tizen-tv-driver/test/global.d.ts
+++ b/packages/appium-tizen-tv-driver/test/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'unexpected';
+declare module 'unexpected-sinon';
+declare module 'unexpected-snapshot';
+declare module 'unexpected-eventemitter';
+declare module 'appium-chromedriver/build/lib/utils';

--- a/packages/appium-tizen-tv-driver/test/helpers.js
+++ b/packages/appium-tizen-tv-driver/test/helpers.js
@@ -1,0 +1,19 @@
+import {server as baseServer, routeConfiguringFunction} from 'appium/driver';
+import TizenTVDriver from '../lib/driver';
+
+export const TEST_HOST = '127.0.0.1';
+
+/**
+ * Starts a server running the Tizen driver
+ * @param {number} port
+ * @param {string} [hostname]
+ * @returns {Promise<import('@appium/types').AppiumServer>}
+ */
+export async function startServer(port, hostname = TEST_HOST) {
+  return await baseServer({
+    routeConfiguringFunction: routeConfiguringFunction(new TizenTVDriver()),
+    port,
+    hostname,
+    cliArgs: /** @type {import('@appium/types').ServerArgs} */(/** @type {unknown} */([]))
+  });
+}

--- a/packages/appium-tizen-tv-driver/tsconfig.json
+++ b/packages/appium-tizen-tv-driver/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "target": "esnext",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "declarationMap": false,
+    "declarationDir": "build",
+    "emitDeclarationOnly": true,
+    "moduleResolution": "node",
+    "types": ["node", "sinon", "mocha"],
+    "resolveJsonModule": true,
+    "composite": true,
+    "paths": {
+      "@headspinio/tizen-remote": ["../tizen-remote"]
+    }
+  },
+  "include": ["lib/**/*", "test/**/*"],
+  "references": [{"path": "../tizen-remote"}]
+}

--- a/packages/tizen-remote/lib/index.js
+++ b/packages/tizen-remote/lib/index.js
@@ -418,6 +418,21 @@ export class TizenRemote extends createdTypedEmitterClass() {
   }
 
   /**
+   * Resolves `true` if a token is set or the cache contains a token
+   * @returns {Promise<boolean>}
+   */
+  async hasToken() {
+    if (this.#token) {
+      return true;
+    }
+    if (this.#persistToken) {
+      const cache = await this.#getTokenCache();
+      return cache.has(this.#tokenCacheKey);
+    }
+    return false;
+  }
+
+  /**
    * Initializes the token cache; otherwise returns the existing cache.
    *
    * Because the `Conf` constructor performs a blocking write to the fs, we need to

--- a/packages/tizen-remote/lib/keys.js
+++ b/packages/tizen-remote/lib/keys.js
@@ -1,7 +1,12 @@
 /**
+ * This is a mapping of key "names" to Tizen remote "key codes" as understood by the websocket API.
+ *
+ * Usually (?), key codes are numbers, but not these!
+ *
+ * Use {@linkcode isRcKeyCode} to check if a string is a valid {@linkcode RcKeyCode}.
  * @group Constants
  */
-export const Keys = /** @type {const} */({
+export const Keys = Object.freeze({
   0: 'KEY_0',
   1: 'KEY_1',
   2: 'KEY_2',
@@ -246,3 +251,4 @@ export const Keys = /** @type {const} */({
   ZOOM1: 'KEY_ZOOM1',
   ZOOM2: 'KEY_ZOOM2',
 });
+

--- a/packages/tizen-sample-app/index.html
+++ b/packages/tizen-sample-app/index.html
@@ -31,11 +31,11 @@
           <input type="text" id="rc-button-name" placeholder="RC Button Name" />
           <input type="text" id="rc-button-code" placeholder="RC Button Code" />
           <pre id="event-data">(no event)</pre>
+          <code id="event-duration">(n/a)</code>ms
       </section>
         <section>
           <h3>Supported RC Buttons</h3>
           <p>This table shows all RC buttons supported by the platform, excluding mandatory buttons mentioned above.</p>
-          <p>Total Count: <code id="supported-btn-count">0</code></p>
           <table id="supported-rc-button-table">
             <thead>
               <tr>

--- a/packages/tizen-sample-app/js/main.js
+++ b/packages/tizen-sample-app/js/main.js
@@ -22,6 +22,7 @@ const init = function () {
         acc[key.code] = key.name;
         return acc;
       }, /** @type {Record<string,string>} */ ({}));
+      $('#supported-btn-raw').text(JSON.stringify(supportedKeys, null, 2));
     } catch (err) {
       $('#supported-btn-raw').text(err.message);
     }

--- a/test/setup.js
+++ b/test/setup.js
@@ -20,13 +20,3 @@
 
 require('@babel/register')({rootMode: 'upward'});
 
-// const chai = require('chai');
-// const chaiAsPromised = require('chai-as-promised');
-// const sinonChai = require('sinon-chai');
-
-// The `chai` global is set if a test needs something special.
-// Most tests won't need this.
-// global.chai = chai.use(chaiAsPromised).use(sinonChai);
-
-// `should()` is only necessary when working with some `null` or `undefined` values.
-// global.should = chai.should();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
   "files": [],
   "references": [{"path": "packages/tizen-remote"}]
 }


### PR DESCRIPTION
This PR adds support for keypresses via RC and chromedriver.  It needs some more tests.

Highlights:

- add a sample app for testing
- let `TizenRemote` force-get a new token
- use `executeMethodMap` to create `tizen: pressKey` and `tizen: longPressKey` methods
- extract chromedriver-executed scripts into their own module (`scripts.js`) and just wrap them when asking chromedriver to run a command
- add E2E tests which work with `tizen-sample-app`
- add types to `appium-tizen-tv-driver`
- add a `--port` flag to `rc-pair` script

