### PR TITLE
fix(appium-tizen-tv-driver,tizen-remote): do not always force token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,10 +68,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/schema": "^0.0.9",
-        "@types/express": "4.17.13",
+        "@types/express": "4.17.14",
         "@types/npmlog": "4.1.4",
         "@types/ws": "8.5.3",
-        "@wdio/types": "7.24.0",
+        "@wdio/types": "7.25.0",
         "type-fest": "2.19.0"
       },
       "engines": {
@@ -17549,7 +17549,7 @@
       }
     },
     "packages/appium-tizen-tv-driver": {
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.18.2",
@@ -17627,7 +17627,7 @@
     },
     "packages/tizen-remote": {
       "name": "@headspinio/tizen-remote",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.18.2",
@@ -17654,7 +17654,7 @@
     },
     "packages/tizen-sample-app": {
       "name": "@headspinio/tizen-sample-app",
-      "version": "0.0.0"
+      "version": "0.1.1"
     }
   },
   "dependencies": {
@@ -17893,10 +17893,10 @@
       "version": "file:../../appium/appium/packages/types",
       "requires": {
         "@appium/schema": "^0.0.9",
-        "@types/express": "4.17.13",
+        "@types/express": "4.17.14",
         "@types/npmlog": "4.1.4",
         "@types/ws": "8.5.3",
-        "@wdio/types": "7.24.0",
+        "@wdio/types": "7.25.0",
         "type-fest": "2.19.0"
       }
     },

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -93,9 +93,6 @@ export const RC_OPTS = {
   name: RC_NAME,
 };
 
-/**
- * @extends {BaseDriver}
- */
 class TizenTVDriver extends BaseDriver {
   static executeMethodMap = Object.freeze({
     'tizen: pressKey': Object.freeze({
@@ -215,7 +212,7 @@ class TizenTVDriver extends BaseDriver {
       // environment or in a cache.
       if (caps.resetRcToken || !(await this.#remote.hasToken())) {
         log.info('Requesting new token; please wait...');
-        await this.#remote.getToken({force: true});
+        await this.#remote.getToken({force: Boolean(caps.resetRcToken)});
       }
     }
 
@@ -564,7 +561,7 @@ export default TizenTVDriver;
 /**
  * @typedef {keyof TizenTVDriverExecuteMethodMap} ScriptId
  * @typedef {BaseTizenTVDriverCaps & Capabilities} TizenTVDriverCaps
- * @typedef {import('@appium/types').AppiumW3CCapabilities & NamespacedObject<BaseTizenTVDriverCaps>} TizenTVDriverW3CCaps
+ * @typedef {import('@appium/types').W3CCapabilities<BaseTizenTVDriverCaps>} TizenTVDriverW3CCaps
  * @typedef {typeof RC_MODE_JS | typeof RC_MODE_REMOTE} RcMode
  * @typedef {typeof TizenTVDriver.executeMethodMap} TizenTVDriverExecuteMethodMap
  */


### PR DESCRIPTION
the only time when we should specifically force a new token is when `appium:resetRcToken` is `true`.

also, immediately after instantiation, unless a token has been provided to `TizenRemote` (or via the env), the `hasToken()` method may resolve `true`, but it will not actually _set_ the token in memory from the cache due to it being a naughty side-effect.  unless `getToken()` was explicitly called, the token would not be set in-memory from the cache before the connection attempt.  the logic has changed so that, at connection time, we attempt to load the token from cache if one exists (and cache persistence is enabled).  if one still doesn't exist after connection, then it will ask for a new one.

also fixes some typescript problems which may actually be a bug in typescript. https://github.com/microsoft/TypeScript/issues/50286

adds a (slow) e2e test suite for checking persistence works