### PR TITLE
feat(tizen-remote): update token when new one received

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -23,13 +23,13 @@ module.exports = (wallaby) => {
       './packages/*/test/**/fixtures/**/*',
       './packages/*/test/**/helpers.js',
       './babel.config.json',
+      './packages/tizen-remote/test/e2e/server.js',
     ],
     testFramework: 'mocha',
     tests: [
       './packages/*/test/unit/**/*.spec.js',
-      './packages/tizen-remote/test/e2e/tizen-remote.e2e.spec.js'
+      './packages/tizen-remote/test/e2e/**/*.e2e.spec.js'
     ],
     runMode: 'onsave',
-    workers: {recycle: true},
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/lodash": "4.14.184",
         "@types/mocha": "9.1.1",
         "@types/node": "18.6.1",
+        "@types/proper-lockfile": "4.1.2",
         "@types/sinon": "10.0.13",
         "@types/teen_process": "1.16.1",
         "@types/ws": "8.5.3",
@@ -4711,6 +4712,15 @@
       "integrity": "sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -13952,6 +13962,24 @@
         "read": "1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "dev": true,
@@ -17200,8 +17228,8 @@
         "debug": "4.3.4",
         "delay": "4.4.1",
         "env-paths": "2.2.1",
-        "lockfile": "1.0.4",
         "p-retry": "4.6.2",
+        "proper-lockfile": "4.1.2",
         "source-map-support": "0.5.21",
         "ws": "8.8.1"
       }
@@ -18503,8 +18531,8 @@
         "debug": "4.3.4",
         "delay": "4.4.1",
         "env-paths": "2.2.1",
-        "lockfile": "1.0.4",
         "p-retry": "4.6.2",
+        "proper-lockfile": "4.1.2",
         "source-map-support": "0.5.21",
         "ws": "8.8.1"
       },
@@ -20422,6 +20450,15 @@
       "integrity": "sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
       }
     },
     "@types/qs": {
@@ -26648,6 +26685,23 @@
       "dev": true,
       "requires": {
         "read": "1"
+      }
+    },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+        }
       }
     },
     "proto-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17113,7 +17113,7 @@
       }
     },
     "packages/appium-tizen-tv-driver": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.18.2",
@@ -17218,7 +17218,7 @@
     },
     "packages/tizen-sample-app": {
       "name": "@headspinio/tizen-sample-app",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/lodash": "4.14.184",
     "@types/mocha": "9.1.1",
     "@types/node": "18.6.1",
+    "@types/proper-lockfile": "4.1.2",
     "@types/sinon": "10.0.13",
     "@types/teen_process": "1.16.1",
     "@types/ws": "8.5.3",

--- a/packages/tizen-remote/index.js
+++ b/packages/tizen-remote/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/lib');
+module.exports = require('./build/lib/tizen-remote');

--- a/packages/tizen-remote/lib/command.js
+++ b/packages/tizen-remote/lib/command.js
@@ -1,14 +1,14 @@
-import {constants} from './index';
+import {constants} from './tizen-remote';
 
 export class KeyCommand {
   method = constants.COMMAND_METHOD;
 
-  /** @type {import('./index').TizenRemoteCommandParams<import('./index').KeyCommandType, import('./index').RcKeyCode>} */
+  /** @type {import('./tizen-remote').TizenRemoteCommandParams<import('./tizen-remote').KeyCommandType, import('./tizen-remote').RcKeyCode>} */
   params;
 
   /**
-   * @param {import('./index').KeyCommandType} cmd
-   * @param {import('./index').RcKeyCode} data
+   * @param {import('./tizen-remote').KeyCommandType} cmd
+   * @param {import('./tizen-remote').RcKeyCode} data
    */
   constructor(cmd, data) {
     this.params = {
@@ -23,7 +23,7 @@ export class KeyCommand {
 export class TextCommand {
   method = constants.COMMAND_METHOD;
 
-  /** @type {import('./index').TizenRemoteCommandParams<string, 'base64'>} */
+  /** @type {import('./tizen-remote').TizenRemoteCommandParams<string, 'base64'>} */
   params;
 
   /**

--- a/packages/tizen-remote/package.json
+++ b/packages/tizen-remote/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "main": "index.js",
-  "types": "build/lib/index.d.ts",
+  "types": "build/lib/tizen-remote.d.ts",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/packages/tizen-remote/package.json
+++ b/packages/tizen-remote/package.json
@@ -51,8 +51,8 @@
     "debug": "4.3.4",
     "delay": "4.4.1",
     "env-paths": "2.2.1",
-    "lockfile": "1.0.4",
     "p-retry": "4.6.2",
+    "proper-lockfile": "4.1.2",
     "source-map-support": "0.5.21",
     "ws": "8.8.1"
   },

--- a/packages/tizen-remote/test/e2e/server.js
+++ b/packages/tizen-remote/test/e2e/server.js
@@ -1,6 +1,6 @@
 import {promisify} from 'node:util';
 import {WebSocketServer} from 'ws';
-import {parse as parseUrl} from 'url';
+import {parse as parseUrl} from 'node:url';
 import d from 'debug';
 import delay from 'delay';
 
@@ -118,6 +118,16 @@ export class TestWSServer extends WebSocketServer {
 
   #stopKeepAliveInterval() {
     clearInterval(this.#keepAliveInterval);
+  }
+
+  /**
+   *
+   * @param {import('type-fest').JsonValue} data
+   */
+  broadcast(data) {
+    for (const ws of this.clients) {
+      ws.send(JSON.stringify(data));
+    }
   }
 
   /**

--- a/packages/tizen-remote/test/unit/tizen-remote.spec.js
+++ b/packages/tizen-remote/test/unit/tizen-remote.spec.js
@@ -13,19 +13,19 @@ describe('TizenRemote', function () {
    */
   let sandbox;
 
-  /** @type {typeof import('../../lib/index').TizenRemote} */
+  /** @type {typeof import('../../lib/tizen-remote').TizenRemote} */
   let TizenRemote;
 
-  /** @type {typeof import('../../lib/index').WsEvent} */
+  /** @type {typeof import('../../lib/tizen-remote').WsEvent} */
   let WsEvent;
 
-  /** @type {typeof import('../../lib/index').Event} */
+  /** @type {typeof import('../../lib/tizen-remote').Event} */
   let Event;
 
   /** @type { {ws: MockWebSocket, '@humanwhocodes/env': {Env: sinon.SinonStub}, conf: typeof MockConf, lockfile: typeof MockLockfile, fs: typeof MockFs}} */
   let mocks;
 
-  /** @type {typeof import('../../lib/index').constants} */
+  /** @type {typeof import('../../lib/tizen-remote').constants} */
   let constants;
 
   /** @type {{get: sinon.SinonStub}} */
@@ -126,7 +126,7 @@ describe('TizenRemote', function () {
       fs: MockFs
     };
     ({TizenRemote, WsEvent, Event, constants} = rewiremock.proxy(
-      () => require('../../lib/index'),
+      () => require('../../lib/tizen-remote'),
       mocks
     ));
   });
@@ -180,7 +180,7 @@ describe('TizenRemote', function () {
   });
 
   describe('instance method', function () {
-    /** @type {import('../../lib/index').TizenRemote} */
+    /** @type {import('../../lib/tizen-remote').TizenRemote} */
     let remote;
 
     beforeEach(function () {


### PR DESCRIPTION
Previously, the lib only updated the cached token (when persistence is enabled) when a) it wasn't present, or b) the `resetRcToken` cap was `true`.

Evidently (?) tokens can expire, so this adds a listener for _unexpected_ "new token" messages and updates the internal token and cache (if applicable) when such a msg is received.

- Also renamed `lib/index.js` to `lib/tizen-remote.js` for sanity purposes
- Expose getters `token` and `tokenCachePath`