### PR TITLE
do not send ENTER after setValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4886,8 +4886,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.2",
-      "license": "MIT",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -20174,7 +20175,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.8.2"
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.5.tgz",
+      "integrity": "sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ=="
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -582,15 +582,12 @@ class TizenTVDriver extends BaseDriver {
           `${TEXT_STRATEGY_PROXY} or ${TEXT_STRATEGY_REMOTE}`
       );
     }
-    this.#remote;
 
     if (this.#isRemoteRcMode && this.opts.sendKeysStrategy === TEXT_STRATEGY_REMOTE) {
       if (Array.isArray(text)) {
         text = text.join('');
       }
-      await /** @type {TizenRemote} */ (this.#remote).text(text);
-      await this.pressKey(Keys.ENTER);
-      return;
+      return await /** @type {TizenRemote} */ (this.#remote).text(text);
     }
 
     return await this.proxyCommand(`/element/${elId}/value`, 'POST', {text});

--- a/packages/appium-tizen-tv-driver/test/unit/driver.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/driver.spec.js
@@ -73,12 +73,11 @@ describe('TizenTVDriver', function () {
           expect(mocks.MockTizenRemote.TizenRemote().text, 'was called once');
         });
 
-        it('should send ENTER', async function () {
+        it('should not send ENTER', async function () {
           await driver.setValue('stuff', 'some-element-id');
           expect(
             mocks.MockTizenRemote.TizenRemote().click,
-            'was called with',
-            mocks.MockTizenRemote.Keys.ENTER
+            'was not called'
           );
         });
       });


### PR DESCRIPTION
As per offline discussion, the current behavior is somewhat unexpected, so we'll just not do that.

Closes #89 ... hopefully.
