### PR TITLE
chore: reset action SHAs for renovate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,16 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install latest npm
         run: npm install -g npm
       - name: Install dependencies
-        uses: bahmutov/npm-install@cb39a46f27f14697fec763d60fb23ad347e2befa # tag=v1
+        uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
       - name: Run smoke, unit & E2E tests
@@ -35,9 +35,9 @@ jobs:
     name: Lint & Check Types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
+      - uses: actions/checkout@v3
       - name: Install dependencies
-        uses: bahmutov/npm-install@cb39a46f27f14697fec763d60fb23ad347e2befa # tag=v1
+        uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
       - name: ESLint
@@ -45,6 +45,6 @@ jobs:
       - name: Check types
         run: npm run build:types
       - name: Validate renovate config
-        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
+        uses: rinchsan/renovate-config-validator@v0.0.12
         with:
           pattern: '.renovaterc.json'


### PR DESCRIPTION
Hopefully this will resolve the "Renovate failed to look up the following dependencies: Could not determine new digest for update (datasource: github-tags)." warning we keep getting.