### PR TITLE
feat(tizen-remote): use per-host token storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/yargs": "17.0.24",
         "@typescript-eslint/eslint-plugin": "5.58.0",
         "@typescript-eslint/parser": "5.58.0",
-        "appium": "next",
+        "appium": "2.0.0-beta.62",
         "conventional-changelog-conventionalcommits": "5.0.0",
         "cross-env": "7.0.3",
         "eslint": "8.38.0",
@@ -58,11 +58,11 @@
       }
     },
     "node_modules/@appium/base-driver": {
-      "version": "9.3.5",
+      "version": "9.3.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^3.1.9",
-        "@appium/types": "^0.10.3",
+        "@appium/support": "^3.1.10",
+        "@appium/types": "^0.10.4",
         "@colors/colors": "1.5.0",
         "@types/async-lock": "1.4.0",
         "@types/bluebird": "3.5.38",
@@ -71,7 +71,7 @@
         "@types/serve-favicon": "2.5.3",
         "async-lock": "1.4.0",
         "asyncbox": "2.9.4",
-        "axios": "1.3.4",
+        "axios": "1.3.5",
         "bluebird": "3.7.2",
         "body-parser": "1.20.2",
         "es6-error": "4.1.1",
@@ -83,8 +83,24 @@
         "morgan": "1.10.0",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "3.7.2",
+        "type-fest": "3.8.0",
         "validate.js": "0.13.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@appium/base-driver/node_modules/@appium/types": {
+      "version": "0.10.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/schema": "^0.2.6",
+        "@appium/tsconfig": "^0.3.0",
+        "@types/express": "4.17.17",
+        "@types/npmlog": "4.1.4",
+        "@types/ws": "8.5.4",
+        "type-fest": "3.8.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -137,12 +153,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/@appium/base-driver/node_modules/type-fest": {
+      "version": "3.8.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@appium/base-plugin": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^9.3.5",
-        "@appium/support": "^3.1.9"
+        "@appium/base-driver": "^9.3.6",
+        "@appium/support": "^3.1.10"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -150,13 +176,12 @@
       }
     },
     "node_modules/@appium/docutils": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-0.3.4.tgz",
-      "integrity": "sha512-BWtw3F6ulqagMPo10h5v2O+puPR4l4N0fLowo697WVxgN2awCYAu3JKr5G2dFGqKewv4r61iLYENBteqm4N1AA==",
+      "version": "0.3.5",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^3.1.9",
-        "@appium/tsconfig": "^0.2.4",
-        "@appium/typedoc-plugin-appium": "^0.6.0",
+        "@appium/support": "^3.1.10",
+        "@appium/tsconfig": "^0.3.0",
+        "@appium/typedoc-plugin-appium": "^0.6.1",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
         "chalk": "4.1.2",
         "consola": "2.15.3",
@@ -172,7 +197,7 @@
         "semver": "7.3.8",
         "source-map-support": "0.5.21",
         "teen_process": "2.0.2",
-        "type-fest": "3.7.2",
+        "type-fest": "3.8.0",
         "typedoc": "0.23.28",
         "typedoc-plugin-markdown": "3.14.0",
         "typedoc-plugin-resolve-crossmodule-references": "0.3.3",
@@ -189,22 +214,9 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@appium/docutils/node_modules/@appium/tsconfig": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.2.4.tgz",
-      "integrity": "sha512-WZTsWjxui4ixbu0C88op1/+XxUPV5C5UNfu82duEQyJQnFtXN6sidTCVUfTdXEpXvJuRdMk31jK0j9yWQOI1Uw==",
-      "dependencies": {
-        "@tsconfig/node14": "1.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=8"
-      }
-    },
     "node_modules/@appium/docutils/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -217,8 +229,7 @@
     },
     "node_modules/@appium/docutils/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -232,8 +243,7 @@
     },
     "node_modules/@appium/docutils/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -245,8 +255,7 @@
     },
     "node_modules/@appium/docutils/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -256,21 +265,18 @@
     },
     "node_modules/@appium/docutils/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "license": "MIT"
     },
     "node_modules/@appium/docutils/node_modules/diff": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/@appium/docutils/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -278,10 +284,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@appium/docutils/node_modules/type-fest": {
+      "version": "3.8.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@appium/docutils/node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -292,8 +307,7 @@
     },
     "node_modules/@appium/docutils/node_modules/yargs": {
       "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -309,8 +323,7 @@
     },
     "node_modules/@appium/docutils/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -364,25 +377,12 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@appium/strongbox": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@appium/strongbox/-/strongbox-0.1.0.tgz",
-      "integrity": "sha512-Ez4BnCQ9YaPSqW32bPd8XbXKJjvIJRbFMxnJZ/u1+8PqrHstpZZB9SjorsMg4rN2+u1bMxJdhGUdDyyGabYFZw==",
-      "dependencies": {
-        "env-paths": "2.2.1",
-        "slugify": "1.6.6"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=8"
-      }
-    },
     "node_modules/@appium/support": {
-      "version": "3.1.9",
+      "version": "3.1.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/tsconfig": "^0.2.4",
-        "@appium/types": "^0.10.3",
+        "@appium/tsconfig": "^0.3.0",
+        "@appium/types": "^0.10.4",
         "@colors/colors": "1.5.0",
         "@types/archiver": "5.3.2",
         "@types/base64-stream": "1.0.2",
@@ -403,7 +403,7 @@
         "@types/teen_process": "2.0.0",
         "@types/uuid": "9.0.1",
         "archiver": "5.3.1",
-        "axios": "1.3.4",
+        "axios": "1.3.5",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
@@ -431,11 +431,11 @@
         "rimraf": "3.0.2",
         "sanitize-filename": "1.6.3",
         "semver": "7.3.8",
-        "shell-quote": "1.8.0",
+        "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "2.0.2",
-        "type-fest": "3.7.2",
+        "type-fest": "3.8.0",
         "uuid": "9.0.0",
         "which": "3.0.0",
         "yauzl": "2.10.0"
@@ -445,12 +445,16 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@appium/support/node_modules/@appium/tsconfig": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.2.4.tgz",
-      "integrity": "sha512-WZTsWjxui4ixbu0C88op1/+XxUPV5C5UNfu82duEQyJQnFtXN6sidTCVUfTdXEpXvJuRdMk31jK0j9yWQOI1Uw==",
+    "node_modules/@appium/support/node_modules/@appium/types": {
+      "version": "0.10.4",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@tsconfig/node14": "1.0.3"
+        "@appium/schema": "^0.2.6",
+        "@appium/tsconfig": "^0.3.0",
+        "@types/express": "4.17.17",
+        "@types/npmlog": "4.1.4",
+        "@types/ws": "8.5.4",
+        "type-fest": "3.8.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -534,10 +538,20 @@
       }
     },
     "node_modules/@appium/support/node_modules/shell-quote": {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@appium/support/node_modules/type-fest": {
+      "version": "3.8.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@appium/support/node_modules/uuid": {
@@ -562,8 +576,7 @@
     },
     "node_modules/@appium/tsconfig": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.0.tgz",
-      "integrity": "sha512-KE4X3KVAUCtAddQA1XvvJABfcTeeb1xQZPdVqEbWld9nH/rqBSQZ7yJozPtktE+80vph5EUp/prMODBWm4WZLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tsconfig/node14": "1.0.3"
       },
@@ -573,14 +586,13 @@
       }
     },
     "node_modules/@appium/typedoc-plugin-appium": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@appium/typedoc-plugin-appium/-/typedoc-plugin-appium-0.6.0.tgz",
-      "integrity": "sha512-ZA9900B72LSRUZRkrRdsrYTYn3neTzmt7VzXarS/lNjC3knmiGtEgVO8Y/aVDRiJQZN8WauQ6o0SiaDlRxmeXw==",
+      "version": "0.6.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "4.7.7",
         "lodash": "4.17.21",
         "pluralize": "8.0.0",
-        "type-fest": "3.7.2"
+        "type-fest": "3.8.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -594,27 +606,9 @@
         "typescript": "^4.7.0 || ^5.0.0"
       }
     },
-    "node_modules/@appium/types": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.10.4.tgz",
-      "integrity": "sha512-dRiNwPUdp9orPvt4eBIenK6BvUIjg+w2E3CO94BSw8R1bObgQCJMdwtXbKrsqt9oREfcC6PfPO9FzKcKJeu8dA==",
-      "dependencies": {
-        "@appium/schema": "^0.2.6",
-        "@appium/tsconfig": "^0.3.0",
-        "@types/express": "4.17.17",
-        "@types/npmlog": "4.1.4",
-        "@types/ws": "8.5.4",
-        "type-fest": "3.8.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@appium/types/node_modules/type-fest": {
+    "node_modules/@appium/typedoc-plugin-appium/node_modules/type-fest": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
-      "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
       },
@@ -670,9 +664,8 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -788,8 +781,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
-      "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1251,24 +1242,21 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3482,9 +3470,8 @@
     },
     "node_modules/@puppeteer/browsers": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.0.tgz",
-      "integrity": "sha512-3iB5pWn9Sr55PKKwqFWSWjLsTKCOEhKNI+uV3BZesgXuA3IhsX8I3hW0HI+3ksMIPkh2mVYzKSpvgq3oicjG2Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -3512,9 +3499,8 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3526,9 +3512,8 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/yargs": {
       "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -3544,9 +3529,8 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -3672,8 +3656,7 @@
     },
     "node_modules/@sliphua/lilconfig-ts-loader": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sliphua/lilconfig-ts-loader/-/lilconfig-ts-loader-3.2.2.tgz",
-      "integrity": "sha512-nX2aBwAykiG50fSUzK9eyA5UvWcrEKzA0ZzCq9mLwHMwpKxM+U05YH8PHba1LJrbeZ7R1HSjJagWKMqFyq8cxw==",
+      "license": "MIT",
       "dependencies": {
         "lodash.get": "^4",
         "make-error": "^1",
@@ -3689,16 +3672,14 @@
     },
     "node_modules/@sliphua/lilconfig-ts-loader/node_modules/diff": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/@sliphua/lilconfig-ts-loader/node_modules/ts-node": {
       "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "license": "MIT",
       "dependencies": {
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
@@ -3744,15 +3725,13 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
@@ -3760,9 +3739,8 @@
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsd/typescript": {
       "version": "5.0.3",
@@ -4127,9 +4105,8 @@
     },
     "node_modules/@types/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -4157,9 +4134,8 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -4389,9 +4365,8 @@
     },
     "node_modules/@wdio/config": {
       "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.8.0.tgz",
-      "integrity": "sha512-gm8gXqpiIR0EU9Blkqmxe+xsEoKS2EXpWrKlx2JXyx3Yf7By0UNsZVZHMSO8lLunzUjYIntpWYpmKmBmnlrnKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "8.6.6",
         "@wdio/types": "8.8.0",
@@ -4408,18 +4383,16 @@
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/decamelize": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4429,9 +4402,8 @@
     },
     "node_modules/@wdio/config/node_modules/find-up": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -4445,9 +4417,8 @@
     },
     "node_modules/@wdio/config/node_modules/glob": {
       "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -4463,9 +4434,8 @@
     },
     "node_modules/@wdio/config/node_modules/locate-path": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -4478,9 +4448,8 @@
     },
     "node_modules/@wdio/config/node_modules/minimatch": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4492,19 +4461,17 @@
       }
     },
     "node_modules/@wdio/config/node_modules/minipass": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.7.tgz",
-      "integrity": "sha512-ScVIgqHcXRMyfflqHmEW0bm8z8rb5McHyOY3ewX9JBgZaR77G7nxq9L/mtV96/QbAAwtbCAHVVLzD1kkyfFQEw==",
+      "version": "4.2.8",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@wdio/config/node_modules/p-limit": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -4517,9 +4484,8 @@
     },
     "node_modules/@wdio/config/node_modules/p-locate": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -4532,18 +4498,16 @@
     },
     "node_modules/@wdio/config/node_modules/path-exists": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/read-pkg": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.1",
         "normalize-package-data": "^3.0.2",
@@ -4559,9 +4523,8 @@
     },
     "node_modules/@wdio/config/node_modules/read-pkg-up": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^6.3.0",
         "read-pkg": "^7.1.0",
@@ -4576,9 +4539,8 @@
     },
     "node_modules/@wdio/config/node_modules/type-fest": {
       "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
       },
@@ -4588,9 +4550,8 @@
     },
     "node_modules/@wdio/config/node_modules/yocto-queue": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -4600,9 +4561,8 @@
     },
     "node_modules/@wdio/logger": {
       "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.6.6.tgz",
-      "integrity": "sha512-MS+Y5yqFGx2zVXMOfuBQAVdFsP4DuYz+/hM552xwiDWjGg6EZHoccqUYgH3J5zpu3JFpYV3R/a5jExFiGGck6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -4615,9 +4575,8 @@
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -4629,7 +4588,8 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.8.1.tgz",
       "integrity": "sha512-nDaycUcm/ATLxcjim0fJyRiezXyyj4ZCq+Xf0S2Cubc0k7+DceFBt7KIMsernNVh2pelzFHEEwxh4DLaqQ71Wg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/repl": {
       "version": "8.6.6",
@@ -4644,9 +4604,8 @@
     },
     "node_modules/@wdio/types": {
       "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.8.0.tgz",
-      "integrity": "sha512-Ai6yIlwWB32FUfvQKCqSa6nSyHIhSF5BOU9OfE7I2XYkLAJTxu8B6NORHQ+rgoppHSWc4D2V9r21y3etF8AGnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0"
       },
@@ -4656,9 +4615,8 @@
     },
     "node_modules/@wdio/utils": {
       "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-JUl1AwdtrJ3GzwtEmLyLohh29ycKkTKQ9S7K5Tc3p4kC3d9YmFKsifVj9riyJUFFrbICO0d35O63kNzsVMYj/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "8.6.6",
         "@wdio/types": "8.8.0",
@@ -4771,9 +4729,8 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4927,17 +4884,16 @@
       }
     },
     "node_modules/appium": {
-      "version": "2.0.0-beta.61",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-2.0.0-beta.61.tgz",
-      "integrity": "sha512-74ifOCLjObtqHXAtMitSRDFyi6ChuwBNBRi+6jNBj/J/exbc3oPSj/wxJ/WbZTt8oK255rMW6ss2eHBlSZi9sg==",
+      "version": "2.0.0-beta.62",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^9.3.5",
-        "@appium/base-plugin": "^2.2.5",
-        "@appium/docutils": "^0.3.4",
+        "@appium/base-driver": "^9.3.6",
+        "@appium/base-plugin": "^2.2.6",
+        "@appium/docutils": "^0.3.5",
         "@appium/schema": "^0.2.6",
-        "@appium/support": "^3.1.9",
-        "@appium/types": "^0.10.3",
+        "@appium/support": "^3.1.10",
+        "@appium/types": "^0.10.4",
         "@sidvind/better-ajv-errors": "2.1.0",
         "@types/argparse": "2.0.10",
         "@types/bluebird": "3.5.38",
@@ -4950,7 +4906,7 @@
         "argparse": "2.0.1",
         "async-lock": "1.4.0",
         "asyncbox": "2.9.4",
-        "axios": "1.3.4",
+        "axios": "1.3.5",
         "bluebird": "3.7.2",
         "cross-env": "7.0.3",
         "find-up": "5.0.0",
@@ -4964,7 +4920,7 @@
         "semver": "7.3.8",
         "source-map-support": "0.5.21",
         "teen_process": "2.0.2",
-        "type-fest": "3.7.2",
+        "type-fest": "3.8.0",
         "winston": "3.8.2",
         "wrap-ansi": "7.0.0",
         "yaml": "2.2.1"
@@ -4979,8 +4935,6 @@
     },
     "node_modules/appium-chromedriver": {
       "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-5.3.4.tgz",
-      "integrity": "sha512-vSw50zqeobrK1YERkGqfAhWLpol9plQTK5w0cRg9fYn48/Ai4LjujsHOsENnyov2d24Adw0Q2hyJya/ACzRtJQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5007,6 +4961,22 @@
     "node_modules/appium-tizen-tv-driver": {
       "resolved": "packages/appium-tizen-tv-driver",
       "link": true
+    },
+    "node_modules/appium/node_modules/@appium/types": {
+      "version": "0.10.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/schema": "^0.2.6",
+        "@appium/tsconfig": "^0.3.0",
+        "@types/express": "4.17.17",
+        "@types/npmlog": "4.1.4",
+        "@types/ws": "8.5.4",
+        "type-fest": "3.8.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
     },
     "node_modules/appium/node_modules/are-we-there-yet": {
       "version": "4.0.0",
@@ -5082,6 +5052,16 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/appium/node_modules/type-fest": {
+      "version": "3.8.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/aproba": {
@@ -5175,8 +5155,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5383,7 +5362,7 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -5956,9 +5935,8 @@
     },
     "node_modules/chrome-launcher": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
-      "integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -5974,9 +5952,8 @@
     },
     "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5986,9 +5963,8 @@
     },
     "node_modules/chromium-bidi": {
       "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.6.tgz",
-      "integrity": "sha512-TQOkWRaLI/IWvoP8XC+7jO4uHTIiAUiklXU1T0qszlUFEai9LgKXIBXy3pOS3EnQZ3bQtMbKUPkug0fTAEHCSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.0"
       },
@@ -6311,8 +6287,7 @@
     },
     "node_modules/consola": {
       "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+      "license": "MIT"
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -6376,9 +6351,8 @@
     },
     "node_modules/conventional-changelog-conventionalcommits": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0",
         "lodash": "^4.17.15",
@@ -6698,8 +6672,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -6719,9 +6692,8 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
       }
@@ -6883,9 +6855,8 @@
     },
     "node_modules/deepmerge-ts": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
-      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -7034,6 +7005,7 @@
       "resolved": "https://registry.npmjs.org/devtools/-/devtools-8.8.1.tgz",
       "integrity": "sha512-IyDesEovenrFOAwEg1Mi/sN4sbDppFAcBK02/U2XNwKc22CrMCoVEKZoK6gDZpjhp2aA9vef4XLhCdPjZCUfAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "@wdio/config": "8.8.0",
@@ -7056,24 +7028,21 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1124027",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1124027.tgz",
-      "integrity": "sha512-OT2sdgQn4llM9/tVcCvoty733KFFIlXVvESceJsfazhmg/dF7C5e3Z8cIN8jNwIikixuE5rufGtD1cvKHXfOcQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/devtools/node_modules/uuid": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/devtools/node_modules/which": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7182,9 +7151,8 @@
     },
     "node_modules/edge-paths": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
-      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -7435,8 +7403,6 @@
     },
     "node_modules/eslint": {
       "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
-      "integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8144,9 +8110,8 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -8164,9 +8129,8 @@
     },
     "node_modules/extract-zip/node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8430,9 +8394,8 @@
     },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.17"
       }
@@ -9409,9 +9372,8 @@
     },
     "node_modules/import-meta-resolve": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10377,9 +10339,8 @@
     },
     "node_modules/ky": {
       "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
-      "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -11043,9 +11004,8 @@
     },
     "node_modules/lighthouse-logger": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.3.0.tgz",
-      "integrity": "sha512-BbqAKApLb9ywUli+0a+PcV04SyJ/N1q/8qgCNe6U97KbPCS1BTksEuHFLYdvc8DltuhfxIUBqDZsC0bBGtl3lA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^2.6.9",
         "marky": "^1.2.2"
@@ -11053,18 +11013,16 @@
     },
     "node_modules/lighthouse-logger/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/lighthouse-logger/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
@@ -11079,9 +11037,8 @@
     },
     "node_modules/lint-staged": {
       "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.2.1.tgz",
-      "integrity": "sha512-8gfzinVXoPfga5Dz/ZOn8I2GOhf81Wvs+KwbEXQn/oWZAvCVS2PivrXfVbFJc93zD16uC0neS47RXHIjXKYZQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "5.2.0",
         "cli-truncate": "^3.1.0",
@@ -11629,9 +11586,8 @@
     },
     "node_modules/loglevel": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
-      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -11642,9 +11598,8 @@
     },
     "node_modules/loglevel-plugin-prefix": {
       "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
-      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -11711,8 +11666,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
       "version": "10.2.0",
@@ -11752,7 +11706,7 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
+      "version": "4.3.0",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -11763,9 +11717,8 @@
     },
     "node_modules/marky": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -12253,9 +12206,8 @@
     },
     "node_modules/mitt": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -12270,9 +12222,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
@@ -13684,9 +13635,8 @@
     },
     "node_modules/p-iteration": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/p-iteration/-/p-iteration-1.1.8.tgz",
-      "integrity": "sha512-IMFBSDIYcPNnW7uWYGrBqmvTiq7W0uB0fJn6shQZs7dlF3OvrHOre+JT9ikSZ7gZS3vWqclVgoQSvToJrns7uQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14289,9 +14239,8 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -14405,9 +14354,8 @@
     },
     "node_modules/puppeteer-core": {
       "version": "19.8.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.5.tgz",
-      "integrity": "sha512-zoGhim/oBQbkND6h4Xz4X7l5DkWVH9wH7z0mVty5qa/c0P1Yad47t/npVtt2xS10BiQwzztWKx7Pa2nJ5yykdw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "0.4.0",
         "chromium-bidi": "0.4.6",
@@ -14435,9 +14383,8 @@
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1107588",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -14463,9 +14410,8 @@
     },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
-      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/querystring": {
       "version": "0.2.0",
@@ -15669,8 +15615,7 @@
     },
     "node_modules/slugify": {
       "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -16150,9 +16095,8 @@
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16162,9 +16106,8 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -16387,9 +16330,8 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16430,9 +16372,8 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -16820,17 +16761,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.2.tgz",
-      "integrity": "sha512-f9BHrLjRJ4MYkfOsnC/53PNDzZJcVo14MqLp2+hXE39p5bgwqohxR5hDZztwxlbxmIVuvC2EFAKrAkokq23PLA==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "license": "MIT",
@@ -16862,8 +16792,7 @@
     },
     "node_modules/typedoc": {
       "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.2.12",
@@ -16892,8 +16821,10 @@
     },
     "node_modules/typedoc-plugin-resolve-crossmodule-references": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-resolve-crossmodule-references/-/typedoc-plugin-resolve-crossmodule-references-0.3.3.tgz",
-      "integrity": "sha512-ZWWBy2WR8z9a6iXYGlyB3KrpV+JDdZv1mndYU6Eh6mInrfMCrQJi3Y5K9ihMBfuaBGB//le1nEmQLgzU3IO+dw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test/packages/*"
+      ],
       "engines": {
         "node": ">=14"
       },
@@ -16909,9 +16840,7 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.5.tgz",
-      "integrity": "sha512-OzOamaOmNBJZUv2qqY1OSWa+++4YPpOkLgkc0w30Oov5ufKlWWXnFUl0l4dgmSv5Shq/zRVkEOXAe2NaqO4l5Q==",
+      "version": "7.4.6",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -16925,8 +16854,6 @@
     },
     "node_modules/typescript": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -16938,8 +16865,6 @@
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
       "dev": true,
       "funding": [
         {
@@ -16951,6 +16876,7 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -16990,9 +16916,8 @@
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -17172,9 +17097,8 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -17236,6 +17160,7 @@
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.8.1.tgz",
       "integrity": "sha512-T6GRq4ubxKz8LBiMIUFGKvGIHeCkOwkI7RkxIHgTMJz0XDJo+9LKsY+wezlIZufoIbNA7d0jphIKOcckRybcaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "@types/ws": "^8.5.3",
@@ -17255,9 +17180,8 @@
     },
     "node_modules/webdriver/node_modules/@sindresorhus/is": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
-      "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -17267,9 +17191,8 @@
     },
     "node_modules/webdriver/node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -17279,18 +17202,16 @@
     },
     "node_modules/webdriver/node_modules/cacheable-lookup": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       }
     },
     "node_modules/webdriver/node_modules/cacheable-request": {
       "version": "10.2.9",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.9.tgz",
-      "integrity": "sha512-CaAMr53AS1Tb9evO1BIWFnZjSr8A4pbXofpsNVWPMDZZj3ZQKHwsQG9BrTqQ4x5ZYJXz1T2b8LLtTZODxSpzbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
@@ -17306,9 +17227,8 @@
     },
     "node_modules/webdriver/node_modules/got": {
       "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
-      "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -17331,9 +17251,8 @@
     },
     "node_modules/webdriver/node_modules/http2-wrapper": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
-      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -17344,9 +17263,8 @@
     },
     "node_modules/webdriver/node_modules/lowercase-keys": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -17356,9 +17274,8 @@
     },
     "node_modules/webdriver/node_modules/mimic-response": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -17368,9 +17285,8 @@
     },
     "node_modules/webdriver/node_modules/normalize-url": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -17380,18 +17296,16 @@
     },
     "node_modules/webdriver/node_modules/p-cancelable": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       }
     },
     "node_modules/webdriver/node_modules/responselike": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -17407,6 +17321,7 @@
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.8.1.tgz",
       "integrity": "sha512-GS6hFG+fle+Rdiv1K2DmcOa6J/eis7xfK1uthlTUiWACVAjloAAR/jGuJaO4FqQMZRIrfK0l+yvglF2/xhXzXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "@wdio/config": "8.8.0",
@@ -17440,18 +17355,16 @@
     },
     "node_modules/webdriverio/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/webdriverio/node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -17461,9 +17374,8 @@
     },
     "node_modules/webdriverio/node_modules/minimatch": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -17916,8 +17828,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -17970,6 +17881,22 @@
         "appium": "^2.0.0-beta.46"
       }
     },
+    "packages/appium-tizen-tv-driver/node_modules/@appium/types": {
+      "version": "0.10.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/schema": "^0.2.6",
+        "@appium/tsconfig": "^0.3.0",
+        "@types/express": "4.17.17",
+        "@types/npmlog": "4.1.4",
+        "@types/ws": "8.5.4",
+        "type-fest": "3.8.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
     "packages/appium-tizen-tv-driver/node_modules/cliui": {
       "version": "8.0.1",
       "license": "ISC",
@@ -17984,8 +17911,7 @@
     },
     "packages/appium-tizen-tv-driver/node_modules/type-fest": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
-      "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
       },
@@ -18021,7 +17947,7 @@
       "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/strongbox": "0.1.0",
+        "@appium/strongbox": "0.2.0",
         "@humanwhocodes/env": "2.2.2",
         "@types/node": "18.15.11",
         "@types/ws": "8.5.4",
@@ -18032,6 +17958,18 @@
         "strict-event-emitter-types": "2.0.0",
         "type-fest": "3.8.0",
         "ws": "8.13.0"
+      }
+    },
+    "packages/tizen-remote/node_modules/@appium/strongbox": {
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "env-paths": "2.2.1",
+        "slugify": "1.6.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
       }
     },
     "packages/tizen-remote/node_modules/type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@types/lodash": "4.14.192",
         "@types/mocha": "10.0.1",
         "@types/node": "18.15.11",
-        "@types/proper-lockfile": "4.1.2",
         "@types/sinon": "10.0.13",
         "@types/teen_process": "2.0.0",
         "@types/yargs": "17.0.24",
@@ -359,6 +358,19 @@
         "@types/json-schema": "7.0.11",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@appium/strongbox": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@appium/strongbox/-/strongbox-0.1.0.tgz",
+      "integrity": "sha512-Ez4BnCQ9YaPSqW32bPd8XbXKJjvIJRbFMxnJZ/u1+8PqrHstpZZB9SjorsMg4rN2+u1bMxJdhGUdDyyGabYFZw==",
+      "dependencies": {
+        "env-paths": "2.2.1",
+        "slugify": "1.6.6"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -4023,14 +4035,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/proper-lockfile": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "license": "MIT"
@@ -5367,13 +5371,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/atomically": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "dev": true,
@@ -6304,28 +6301,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/conf": {
-      "version": "10.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.6.3",
-        "ajv-formats": "^2.1.1",
-        "atomically": "^1.7.0",
-        "debounce-fn": "^4.0.0",
-        "dot-prop": "^6.0.1",
-        "env-paths": "^2.2.1",
-        "json-schema-typed": "^7.0.3",
-        "onetime": "^5.1.2",
-        "pkg-up": "^3.1.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/config-chain": {
       "version": "1.1.12",
       "dev": true,
@@ -6827,26 +6802,6 @@
         "node": "*"
       }
     },
-    "node_modules/debounce-fn": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/debounce-fn/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "license": "MIT",
@@ -7196,6 +7151,7 @@
     },
     "node_modules/dot-prop": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -9861,6 +9817,7 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10306,10 +10263,6 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "7.0.3",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13844,6 +13797,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14217,67 +14171,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/plist": {
       "version": "3.0.6",
       "license": "MIT",
@@ -14450,22 +14343,6 @@
       "license": "ISC",
       "dependencies": {
         "read": "1"
-      }
-    },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/proto-list": {
@@ -15788,6 +15665,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/smart-buffer": {
@@ -18136,16 +18021,14 @@
       "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@appium/strongbox": "0.1.0",
         "@humanwhocodes/env": "2.2.2",
         "@types/node": "18.15.11",
         "@types/ws": "8.5.4",
-        "conf": "10.2.0",
         "debug": "4.3.4",
         "delay": "4.4.1",
-        "env-paths": "2.2.1",
         "lodash": "4.17.21",
         "p-retry": "4.6.2",
-        "proper-lockfile": "4.1.2",
         "strict-event-emitter-types": "2.0.0",
         "type-fest": "3.8.0",
         "ws": "8.13.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/yargs": "17.0.24",
     "@typescript-eslint/eslint-plugin": "5.58.0",
     "@typescript-eslint/parser": "5.58.0",
-    "appium": "next",
+    "appium": "2.0.0-beta.62",
     "conventional-changelog-conventionalcommits": "5.0.0",
     "cross-env": "7.0.3",
     "eslint": "8.38.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@types/lodash": "4.14.192",
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.11",
-    "@types/proper-lockfile": "4.1.2",
     "@types/sinon": "10.0.13",
     "@types/teen_process": "2.0.0",
     "@types/yargs": "17.0.24",

--- a/packages/tizen-remote/README.md
+++ b/packages/tizen-remote/README.md
@@ -5,13 +5,12 @@
 ## Basic Usage
 
 ```js
-import { TizenRemote, Keys } from '@headspinio/tizen-remote';
+import {TizenRemote, Keys} from '@headspinio/tizen-remote';
 
 const remote = new TizenRemote({
   host: 'my-tizen.device.local',
   port: 12345,
-  token: 'my-secret-token',
-  appId: 'my.app-id'
+  appId: 'my.app-id',
 });
 
 await remote.connect();
@@ -27,6 +26,7 @@ This package acts as a WebSocket client for the Tizen Remote API and provides va
 ## Features
 
 - Connects to a Tizen device's remote control service via WebSocket
+- Automatic pairing of remote control with the device (token stored per host)
 - Allows automation of keypresses
 - Supports auto-reconnection on unexpected disconnect
 - Supports multiple connection attempts with exponential backoff
@@ -39,7 +39,11 @@ npm i @headspinio/tizen-remote
 
 ## API
 
-(link API docs here)
+(TODO)
+
+## Environment
+
+If a `token` option is not provided via the `TizenRemote` constructor's options, this library will look for a token in the `TIZEN_REMOTE_TOKEN` environment variable (if neither are found, automatic pairing is attempted).
 
 ## License
 

--- a/packages/tizen-remote/lib/types.ts
+++ b/packages/tizen-remote/lib/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Options for {@linkcode TizenRemote}.
+ *
+ * @group Options
+ */
+export interface TizenRemoteOptions {
+  /**
+   * Remote control token
+   */
+  token?: string;
+  /**
+   * Port of the Tizen device's WS server
+   */
+  port?: number | string;
+  /**
+   * Whether to use SSL
+   */
+  ssl?: boolean;
+  /**
+   * Timeout for the initial handshake (ms)
+   */
+  handshakeTimeout?: number;
+  /**
+   * Number of retries for the initial handshake
+   */
+  handshakeRetries?: number;
+  /**
+   * Timeout for the token request (ms)
+   */
+  tokenTimeout?: number;
+  /**
+   * Whether to automatically reconnect on disconnection
+   */
+  autoReconnect?: boolean;
+  /**
+   * Whether to persist the token to disk _and_ whether to read it from disk when needed
+   */
+  persistToken?: boolean;
+  /**
+   * Whether to enable debug logging
+   */
+  debug?: boolean;
+}

--- a/packages/tizen-remote/package.json
+++ b/packages/tizen-remote/package.json
@@ -45,16 +45,14 @@
     "test:types": "tsd"
   },
   "dependencies": {
+    "@appium/strongbox": "0.1.0",
     "@humanwhocodes/env": "2.2.2",
     "@types/node": "18.15.11",
     "@types/ws": "8.5.4",
-    "conf": "10.2.0",
     "debug": "4.3.4",
     "delay": "4.4.1",
-    "env-paths": "2.2.1",
     "lodash": "4.17.21",
     "p-retry": "4.6.2",
-    "proper-lockfile": "4.1.2",
     "strict-event-emitter-types": "2.0.0",
     "type-fest": "3.8.0",
     "ws": "8.13.0"

--- a/packages/tizen-remote/package.json
+++ b/packages/tizen-remote/package.json
@@ -45,7 +45,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@appium/strongbox": "0.1.0",
+    "@appium/strongbox": "0.2.0",
     "@humanwhocodes/env": "2.2.2",
     "@types/node": "18.15.11",
     "@types/ws": "8.5.4",

--- a/packages/tizen-remote/test/e2e/tizen-remote.e2e.spec.js
+++ b/packages/tizen-remote/test/e2e/tizen-remote.e2e.spec.js
@@ -53,7 +53,7 @@ describe('websocket behavior', function () {
   /** @type {sinon.SinonSandbox} */
   let sandbox;
 
-  /** @type {import('../../lib/tizen-remote').TizenRemoteOptions} */
+  /** @type {import('../../lib/types').TizenRemoteOptions} */
   let remoteOpts;
 
   /** @type {string} */
@@ -398,12 +398,8 @@ describe('websocket behavior', function () {
             });
           }));
 
-          const tokenCache = JSON.parse(await fs.readFile(/** @type {string} */(remote.tokenCachePath), 'utf8'));
-          expect(tokenCache, 'to satisfy', {
-            [remote.base64Name]: {
-              token: newToken,
-            },
-          });
+          const token = await fs.readFile(/** @type {string} */(remote.tokenCachePath), 'utf8');
+          expect(token, 'to equal', newToken);
         });
       });
 


### PR DESCRIPTION
BREAKING CHANGE: Uses a new scheme for token storage. Instead of a single JSON file, we use one file per device.  This will break existing token stores.  Also, the `name` option of the `TizenRemote` constructor is no longer recognized.

This replaces the bespoke token cache with the `@appium/strongbox` package.  As such, it mitigates the need for lockfiles.

* * *

_The build should fail until appium/appium#18480 is merged and released._
