### PR TITLE
Fix issue on windows when spaces were seen at the end of the lines while parsing the results of the applist call

### DIFF
--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -2,7 +2,7 @@ import log from '../logger';
 import {runCmd, SDB_BIN_NAME} from './helpers';
 
 const DEBUG_PORT_RE = /^(?:.*port:\s)(?<port>\d{1,5})$/;
-const APP_LIST_RE = /^[^']*'(?<name>[^']*)'[^']+'(?<id>[^']+)'.*$/;
+const APP_LIST_RE = /^[^']*'(?<name>[^']*)'[^']+'(?<id>[^']+)'\s*$/;
 
 /**
  *

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -28,7 +28,35 @@ describe('sdb', function () {
         { appName: 'PBS Video', appPackage: '70fRFUwYlD.OtterGAProd' },
         { appName: 'iacr', appPackage: 'com.samsung.tv.iacr' },
         { appName: 'Samsung Health', appPackage: 'com.samsung.tv.samsung-health' },
-         { appName: '', appPackage: 'com.samsung.tv.remoteapp.local_stream' }
+        { appName: '', appPackage: 'com.samsung.tv.remoteapp.local_stream' }
+      ]);
+    });
+  });
+
+  describe('_parseListAppsCmd with spaces and bad data', function () {
+    it('should return the list of apps', function () {
+      const returnValue = "\tApplication List for user 5001\r\n\tUser's Application \r\n\t Name \t AppID \r\n\t=================================================\r\n\t'alexa-fullscreen-app'\t 'com.samsung.tv.alexa-client-xapp-ut-on-tv'   \r\n\t'ContentSharing.Provider.Ftp'\t 'com.samsung.tv.coss.provider.d2d'      \r\n\t'Xbox'\t 'GHI3a0zMSx.XboxGamePass'     \r\n\t'not-a-real-app'\t 'should.not.work.string' baddata\r\n\t'cloning'\t 'org.tizen.cloning'\r\n\t'csfs'\t 'com.samsung.tv.csfs'\r\n\t'あ'\t 'pIaMf8YZyZ.service'\r\n\t'service-application'\t 'org.tizen.was-appsync'\r\n\t'fuzzy-search-engine'\t 'com.samsung.tv.fuzzy-search-engine'\r\n\t'pisa-control-service'\t 'org.tizen.pisa-control-service'\r\n\t'SmartThings Home CCTV Service'\t 'com.samsung.tv.iot-service-home-cctv_FLUX'\r\n\t'samsung-pass'\t 'com.samsung.tizen.samsung-pass-agent'\r\n\t'pluginplatform'\t 'com.samsung.tizen.smartthings-plugin-platform'\r\n\t'LibAriaFW'\t 'lib-ariafw-tv'\r\n\t'com.samsung.tv.ondevice-voice'\t 'com.samsung.tv.ondevice-voice'\r\n\t'PBS Video'\t '70fRFUwYlD.OtterGAProd'\r\n\t'iacr'\t 'com.samsung.tv.iacr'\r\n\t'Samsung Health'\t 'com.samsung.tv.samsung-health'\r\n\t''\t 'com.samsung.tv.remoteapp.local_stream'\r\n\t=================================================\r\n";
+
+      // Spaces in the app name should exist as-is.
+      expect(_parseListAppsCmd(returnValue), 'to equal', [
+        { appName: 'alexa-fullscreen-app', appPackage: 'com.samsung.tv.alexa-client-xapp-ut-on-tv' },
+        { appName: 'ContentSharing.Provider.Ftp', appPackage: 'com.samsung.tv.coss.provider.d2d' },
+        { appName: 'Xbox', appPackage: 'GHI3a0zMSx.XboxGamePass' },
+        { appName: 'cloning', appPackage: 'org.tizen.cloning' },
+        { appName: 'csfs', appPackage: 'com.samsung.tv.csfs' },
+        { appName: 'あ', appPackage: 'pIaMf8YZyZ.service' },
+        { appName: 'service-application', appPackage: 'org.tizen.was-appsync' },
+        { appName: 'fuzzy-search-engine', appPackage: 'com.samsung.tv.fuzzy-search-engine' },
+        { appName: 'pisa-control-service', appPackage: 'org.tizen.pisa-control-service' },
+        { appName: 'SmartThings Home CCTV Service', appPackage: 'com.samsung.tv.iot-service-home-cctv_FLUX' },
+        { appName: 'samsung-pass', appPackage: 'com.samsung.tizen.samsung-pass-agent' },
+        { appName: 'pluginplatform', appPackage: 'com.samsung.tizen.smartthings-plugin-platform' },
+        { appName: 'LibAriaFW', appPackage: 'lib-ariafw-tv' },
+        { appName: 'com.samsung.tv.ondevice-voice', appPackage: 'com.samsung.tv.ondevice-voice' },
+        { appName: 'PBS Video', appPackage: '70fRFUwYlD.OtterGAProd' },
+        { appName: 'iacr', appPackage: 'com.samsung.tv.iacr' },
+        { appName: 'Samsung Health', appPackage: 'com.samsung.tv.samsung-health' },
+        { appName: '', appPackage: 'com.samsung.tv.remoteapp.local_stream' }
       ]);
     });
   });


### PR DESCRIPTION
During testing on windows we found times when the strings returned from applist contained extra spaces which would cause problems.  When this happened the method _parseListAppsCmd would return no results which would cause automation to fail because the expected app was not installed.

Validated locally with a device which was showing the issue.

Added an additional unit test which had a string both with added spaces as well as trash on one line.  This allowed us to verify if we just see spaces at the end we are ok, but if we see trash then the line will be ignored.