### PR TITLE
chore: better error message

### DIFF
--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -396,11 +396,20 @@ class TizenTVDriver extends BaseDriver {
    * @returns {Promise<number>}
    */
   async setupDebugger(caps) {
-    const remoteDebugPort =
-      caps.useOpenDebugPort ||
-      (await debugApp(
-        /** @type {import('type-fest').SetRequired<typeof caps, 'appPackage'>} */ (caps)
-      ));
+    let remoteDebugPort;
+
+    if (!caps.useOpenDebugPort) {
+      try {
+        remoteDebugPort = await debugApp(
+          /** @type {import('type-fest').SetRequired<typeof caps, 'appPackage'>} */ (caps)
+        );
+      } catch (e) {
+        throw new errors.SessionNotCreatedError(`Failed to launch ${caps.appPackage} as debug mode. It might not be debuggable. Original error: ${e.message}`);
+      }
+    } else {
+      remoteDebugPort = caps.useOpenDebugPort;
+    }
+
     const localDebugPort = await getPort();
     log.info(`Chose local port ${localDebugPort} for remote debug communication`);
     await forwardPort({


### PR DESCRIPTION
If the test apps was not debuggable, current error returns:

```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Command 'sdb -s 192.168.11.41\:26101 shell 0 debug 9Ur5IzDKqV.TizenYouTube' exited with code 1. Stdout was: ''. Stderr was: 'closed '
from UnknownError: An unknown server-side error occurred while processing the command. Original error: Command 'sdb -s 192.168.11.41\:26101 shell 0 debug 9Ur5IzDKqV.TizenYouTube' exited with code 1. Stdout was: ''. Stderr was: 'closed '
```

which is not helpful since no idea what made the error.

So, this is a small tweak but maybe it would be slightly helpful the given package may not be debuggable:

```
Selenium::WebDriver::Error::SessionNotCreatedError: A new session could not be created. Details: Failed to launch 9Ur5IzDKqV.TizenYouTube as debug mode. It might not be debuggable. Original error: Command 'sdb -s 192.168.11.41\:26101 shell 0 debug 9Ur5IzDKqV.TizenYouTube' exited with code 1. Stdout was: ''. Stderr was: 'closed '
from SessionNotCreatedError: A new session could not be created. Details: Failed to launch 9Ur5IzDKqV.TizenYouTube as debug mode. It might not be debuggable. Original error: Command '/sdb -s 192.168.11.41\:26101 shell 0 debug 9Ur5IzDKqV.TizenYouTube' exited with code 1. Stdout was: ''. Stderr was: 'closed '
````