### PR TITLE
chore: show explanation in the log when 401 occurrs

### DIFF
--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -1,6 +1,7 @@
 import yargs from 'yargs/yargs';
 import {TizenRemote, Keys as KEYS} from '@headspinio/tizen-remote';
 import {RC_OPTS} from './driver';
+import got from 'got'
 
 /**
  *
@@ -8,6 +9,13 @@ import {RC_OPTS} from './driver';
  * @returns {Promise<void>}
  */
 export async function pairRemote({host, port}) {
+  try {
+    await got.get(`http://${host}:8001`);
+  } catch (err) {
+    console.log(`The device ${host} might be denied in the past pairing. Please make sure that the device ${host} has no denied devices, especially named '${host}'.`)
+    throw err;
+  }
+
   const rc = new TizenRemote(host, {...RC_OPTS, port});
 
   try {

--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -1,7 +1,7 @@
 import yargs from 'yargs/yargs';
 import {TizenRemote, Keys as KEYS} from '@headspinio/tizen-remote';
 import {RC_OPTS} from './driver';
-import got from 'got'
+import got from 'got';
 
 /**
  *
@@ -12,7 +12,7 @@ export async function pairRemote({host, port}) {
   try {
     await got.get(`http://${host}:8001`);
   } catch (err) {
-    console.log(`The device ${host} might be denied in the past pairing. Please make sure that the device ${host} has no denied devices, especially named '${host}'.`)
+    console.log(`The device ${host} might be denied in the past pairing. Please make sure that the device ${host} has no denied devices, especially named '${host}'.`); // eslint-disable-line no-console
     throw err;
   }
 


### PR DESCRIPTION
Print slightly better error log in https://github.com/headspinio/appium-tizen-tv-driver/pull/592 case:

error example:
```
The device 123.456.789.10 might be denied in the past pairing. Please make sure the device 123.456.789.10 had no denied devices, especially named '123.456.789.10'.

appium-tizen-tv-driver/node_modules/got/dist/source/as-promise/index.js:118
                    request._beforeError(new types_1.HTTPError(response));
                                         ^
HTTPError: Response code 401 (Unauthorized)
    at Request.<anonymous> (/appium-tizen-tv-driver/node_modules/got/dist/source/as-promise/index.js:118:42)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
✖ Encountered an error when running 'pair-remote': Script "pair-remote" exited with code 1

```