### PR TITLE
fix: improved non token supported device handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19641,6 +19641,7 @@
         "@types/ws": "8.5.5",
         "debug": "4.3.4",
         "delay": "4.4.1",
+        "got": "11.8.6",
         "lodash": "4.17.21",
         "p-retry": "4.6.2",
         "strict-event-emitter-types": "2.0.0",

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -331,7 +331,7 @@ class TizenTVDriver extends BaseDriver {
           `but it may be ignorable. Proceeding the app installation.`);
       }
       if (_.isArray(installedPackages) && !installedPackages.includes(caps.appPackage)) {
-        throw new errors.SessionNotCreatedError(`${caps.appPackage} does not exist on the device.`);
+        log.info(`${caps.appPackage} might not exist on the device, or the TV model is old thus no installed app information.`);
       }
     }
 

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -331,7 +331,7 @@ class TizenTVDriver extends BaseDriver {
           `but it may be ignorable. Proceeding the app installation.`);
       }
       if (_.isArray(installedPackages) && !installedPackages.includes(caps.appPackage)) {
-        log.info(`${caps.appPackage} might not exist on the device, or the TV model is old thus no installed app information.`);
+        log.info(`${caps.appPackage} might not exist on the device, or the TV model is old thus no installed app information existed.`);
       }
     }
 

--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -29,7 +29,7 @@ export async function pairRemote({host, port}) {
       throw new Error(`Could not retrieve token; please try allowing the remote again`);
     }
 
-    console.log('The device may not token supported device. Allowing the notification is sufficient.'); // eslint-disable-line no-console
+    console.log('The device may not support token-based authentication. Allowing the pop-up notification is sufficient.'); // eslint-disable-line no-console
   } finally {
     await rc.disconnect();
   }

--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -29,7 +29,7 @@ export async function pairRemote({host, port}) {
       throw new Error(`Could not retrieve token; please try allowing the remote again`);
     }
 
-    console.log('The device may not token supported device. Allowing the notification is sufficient.');  // eslint-disable-line no-console
+    console.log('The device may not token supported device. Allowing the notification is sufficient.'); // eslint-disable-line no-console
   } finally {
     await rc.disconnect();
   }

--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -16,12 +16,6 @@ export async function pairRemote({host, port}) {
     throw err;
   }
 
-  const deviceData = await got.get(`http://${host}:8001/api/v2/`).json();
-  if (deviceData?.device?.TokenAuthSupport === undefined) {
-    console.log('The device may not have TokenAuthSupport availability. It does not require remote control token. Please use rcMode=remote without token.'); // eslint-disable-line no-console
-    return;
-  }
-
   const rc = new TizenRemote(host, {...RC_OPTS, port});
 
   try {
@@ -30,7 +24,12 @@ export async function pairRemote({host, port}) {
       console.log(token); // eslint-disable-line no-console
       return;
     }
-    throw new Error(`Could not retrieve token; please try allowing the remote again`);
+
+    if (await rc.isTokenSupportedDevice()) {
+      throw new Error(`Could not retrieve token; please try allowing the remote again`);
+    }
+
+    console.log('The device may not token supported device. Allowing the notification is sufficient.');  // eslint-disable-line no-console
   } finally {
     await rc.disconnect();
   }

--- a/packages/appium-tizen-tv-driver/lib/rc-pair.js
+++ b/packages/appium-tizen-tv-driver/lib/rc-pair.js
@@ -16,6 +16,12 @@ export async function pairRemote({host, port}) {
     throw err;
   }
 
+  const deviceData = await got.get(`http://${host}:8001/api/v2/`).json();
+  if (deviceData?.device?.TokenAuthSupport === undefined) {
+    console.log('The device may not have TokenAuthSupport availability. It does not require remote control token. Please use rcMode=remote without token.'); // eslint-disable-line no-console
+    return;
+  }
+
   const rc = new TizenRemote(host, {...RC_OPTS, port});
 
   try {

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -712,7 +712,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
    *
    * If a new token must be requested, expect to wait _at least_ thirty (30) seconds.
    * @param {NoConnectOption & {force?: boolean}} opts
-   * @returns {Promise<string | null>}
+   * @returns {Promise<string | undefined>}
    */
   async getToken({noConnect = false, force = false} = {}) {
     if (!force) {
@@ -746,7 +746,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
         throw new Error(`Could not get token; server responded with: ${format('%O', res)}`);
       }
       this.#debug('The device may not support token as old model.');
-      return null;
+      return undefined;
     } finally {
       this.#onWs(WsEvent.MESSAGE, this.#updateTokenListener, {context: this});
     }

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -394,9 +394,22 @@ export class TizenRemote extends createdTypedEmitterClass() {
     if (_.isBoolean(this.#tokenSupportCache)) {
       return this.#tokenSupportCache;
     }
-    const deviceData = await got.get(`http://${this.#host}:8001/api/v2/`).json();
-    this.#tokenSupportCache = deviceData?.device?.TokenAuthSupport === 'true';
-    return this.#tokenSupportCache;
+    try {
+      const deviceData = await got.get(`http://${this.#host}:8001/api/v2/`).json();
+      this.#tokenSupportCache = this._getTokenSupportDevice(deviceData) === 'true';
+      return this.#tokenSupportCache;
+    } catch {
+      // defaults to true for newer TVs.
+      return true;
+    }
+  }
+  /**
+   * Private. Accessible for testing
+   * @param {any} jsonBody
+   * @returns {'true'|'false'|undefined}
+   */
+  _getTokenSupportDevice(jsonBody) {
+    return jsonBody?.device?.TokenAuthSupport;
   }
 
   /**

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -712,7 +712,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
    *
    * If a new token must be requested, expect to wait _at least_ thirty (30) seconds.
    * @param {NoConnectOption & {force?: boolean}} opts
-   * @returns {Promise<string>}
+   * @returns {Promise<string | null>}
    */
   async getToken({noConnect = false, force = false} = {}) {
     if (!force) {
@@ -746,6 +746,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
         throw new Error(`Could not get token; server responded with: ${format('%O', res)}`);
       }
       this.#debug('The device may not support token as old model.');
+      return null;
     } finally {
       this.#onWs(WsEvent.MESSAGE, this.#updateTokenListener, {context: this});
     }

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -396,7 +396,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
     }
     try {
       const deviceData = await got.get(`http://${this.#host}:8001/api/v2/`).json();
-      this.#tokenSupportCache = this._getTokenSupportDevice(deviceData) === 'true';
+      this.#tokenSupportCache = this._getDeviceSupportsTokens(deviceData) === 'true';
       return this.#tokenSupportCache;
     } catch {
       // defaults to true for newer TVs.
@@ -408,7 +408,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
    * @param {any} jsonBody
    * @returns {'true'|'false'|undefined}
    */
-  _getTokenSupportDevice(jsonBody) {
+  _getDeviceSupportsTokens(jsonBody) {
     return jsonBody?.device?.TokenAuthSupport;
   }
 
@@ -759,7 +759,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
         throw new Error(`Could not get token; server responded with: ${format('%O', res)}`);
       }
       this.#debug('The device may not support token as old model.');
-      return undefined;
+      return;
     } finally {
       this.#onWs(WsEvent.MESSAGE, this.#updateTokenListener, {context: this});
     }

--- a/packages/tizen-remote/package.json
+++ b/packages/tizen-remote/package.json
@@ -51,6 +51,7 @@
     "@types/ws": "8.5.5",
     "debug": "4.3.4",
     "delay": "4.4.1",
+    "got": "11.8.6",
     "lodash": "4.17.21",
     "p-retry": "4.6.2",
     "strict-event-emitter-types": "2.0.0",

--- a/packages/tizen-remote/test/e2e/tizen-remote.e2e.spec.js
+++ b/packages/tizen-remote/test/e2e/tizen-remote.e2e.spec.js
@@ -56,13 +56,13 @@ describe('websocket behavior', function () {
   /** @type {import('../../lib/types').TizenRemoteOptions} */
   let remoteOpts;
 
-  /** @type {string} */
+  /** @type {string|undefined} */
   let token;
 
   /**
    * Connects, gets a token, disconnects.
    * @param {number} port
-   * @returns {Promise<string>}
+   * @returns {Promise<string|undefined>}
    */
   async function getInitialToken(port) {
     const remote = new TizenRemote(HOST, {

--- a/packages/tizen-remote/test/unit/tizen-remote.spec.js
+++ b/packages/tizen-remote/test/unit/tizen-remote.spec.js
@@ -362,5 +362,135 @@ describe('TizenRemote', function () {
         });
       });
     });
+
+    describe('isTokenSupportedDevice()', function () {
+      beforeEach(function () {
+        remote = new TizenRemote('host');
+    });
+    describe('with TokenAuthSupport', function () {
+        it('should true', function () {
+          const r = remote._getTokenSupportDevice({
+            'device': {
+              'FrameTVSupport': 'false',
+              'GamePadSupport': 'true',
+              'ImeSyncedSupport': 'true',
+              'Language': 'en_US',
+              'OS': 'Tizen',
+              'PowerState': 'on',
+              'TokenAuthSupport': 'true',
+              'VoiceSupport': 'true',
+              'WallScreenRatio': '0',
+              'WallService': 'false',
+              'countryCode': 'CA',
+              'description': 'Samsung DTV RCR',
+              'developerIP': '192.168.11.147',
+              'developerMode': '1',
+              'duid': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'firmwareVersion': 'Unknown',
+              'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'ip': '192.168.11.41',
+              'model': '19_MUSEM_UHD',
+              'modelName': 'UN49RU8000FXZC',
+              'name': 'tv',
+              'networkType': 'wired',
+              'resolution': '3840x2160',
+              'smartHubAgreement': 'true',
+              'type': 'Samsung SmartTV',
+              'udn': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'wifiMac': '00:7c:2d:d5:22:f3'
+            },
+            'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+            'isSupport': '{"DMP_DRM_PLAYREADY":"false","DMP_DRM_WIDEVINE":"false","DMP_available":"true","EDEN_available":"true","FrameTVSupport":"false","ImeSyncedSupport":"true","TokenAuthSupport":"true","remote_available":"true","remote_fourDirections":"true","remote_touchPad":"true","remote_voiceControl":"true"}\n',
+            'name': 'tv',
+            'remote': '1.0',
+            'type': 'Samsung SmartTV',
+            'uri': 'http://192.168.11.41:8001/api/v2/',
+            'version': '2.0.25'
+          });
+          expect(r, 'to equal', 'true');
+        });
+        it('should false', function () {
+          const r = remote._getTokenSupportDevice({
+            'device': {
+              'FrameTVSupport': 'false',
+              'GamePadSupport': 'true',
+              'ImeSyncedSupport': 'true',
+              'Language': 'en_US',
+              'OS': 'Tizen',
+              'PowerState': 'on',
+              'TokenAuthSupport': 'false',
+              'VoiceSupport': 'true',
+              'WallScreenRatio': '0',
+              'WallService': 'false',
+              'countryCode': 'CA',
+              'description': 'Samsung DTV RCR',
+              'developerIP': '192.168.11.147',
+              'developerMode': '1',
+              'duid': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'firmwareVersion': 'Unknown',
+              'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'ip': '192.168.11.41',
+              'model': '19_MUSEM_UHD',
+              'modelName': 'UN49RU8000FXZC',
+              'name': 'tv',
+              'networkType': 'wired',
+              'resolution': '3840x2160',
+              'smartHubAgreement': 'true',
+              'type': 'Samsung SmartTV',
+              'udn': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'wifiMac': '00:7c:2d:d5:22:f3'
+            },
+            'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+            'isSupport': '{"DMP_DRM_PLAYREADY":"false","DMP_DRM_WIDEVINE":"false","DMP_available":"true","EDEN_available":"true","FrameTVSupport":"false","ImeSyncedSupport":"true","TokenAuthSupport":"false","remote_available":"true","remote_fourDirections":"true","remote_touchPad":"true","remote_voiceControl":"true"}\n',
+            'name': 'tv',
+            'remote': '1.0',
+            'type': 'Samsung SmartTV',
+            'uri': 'http://192.168.11.41:8001/api/v2/',
+            'version': '2.0.25'
+          });
+          expect(r, 'to equal', 'false');
+        });
+        it('should null', function () {
+          const r = remote._getTokenSupportDevice({
+            'device': {
+              'FrameTVSupport': 'false',
+              'GamePadSupport': 'true',
+              'ImeSyncedSupport': 'true',
+              'Language': 'en_US',
+              'OS': 'Tizen',
+              'PowerState': 'on',
+              'VoiceSupport': 'true',
+              'WallScreenRatio': '0',
+              'WallService': 'false',
+              'countryCode': 'CA',
+              'description': 'Samsung DTV RCR',
+              'developerIP': '192.168.11.147',
+              'developerMode': '1',
+              'duid': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'firmwareVersion': 'Unknown',
+              'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'ip': '192.168.11.41',
+              'model': '19_MUSEM_UHD',
+              'modelName': 'UN49RU8000FXZC',
+              'name': 'tv',
+              'networkType': 'wired',
+              'resolution': '3840x2160',
+              'smartHubAgreement': 'true',
+              'type': 'Samsung SmartTV',
+              'udn': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+              'wifiMac': '00:7c:2d:d5:22:f3'
+            },
+            'id': 'uuid:94a93b85-fe59-46aa-9007-6d25b52df02b',
+            'isSupport': '{"DMP_DRM_PLAYREADY":"false","DMP_DRM_WIDEVINE":"false","DMP_available":"true","EDEN_available":"true","FrameTVSupport":"false","ImeSyncedSupport":"true","remote_available":"true","remote_fourDirections":"true","remote_touchPad":"true","remote_voiceControl":"true"}\n',
+            'name': 'tv',
+            'remote': '1.0',
+            'type': 'Samsung SmartTV',
+            'uri': 'http://192.168.11.41:8001/api/v2/',
+            'version': '2.0.25'
+          });
+          expect(r, 'to equal', undefined);
+        });
+      });
+    });
   });
 });

--- a/packages/tizen-remote/test/unit/tizen-remote.spec.js
+++ b/packages/tizen-remote/test/unit/tizen-remote.spec.js
@@ -369,7 +369,7 @@ describe('TizenRemote', function () {
     });
     describe('with TokenAuthSupport', function () {
         it('should true', function () {
-          const r = remote._getTokenSupportDevice({
+          const r = remote._getDeviceSupportsTokens({
             'device': {
               'FrameTVSupport': 'false',
               'GamePadSupport': 'true',
@@ -410,7 +410,7 @@ describe('TizenRemote', function () {
           expect(r, 'to equal', 'true');
         });
         it('should false', function () {
-          const r = remote._getTokenSupportDevice({
+          const r = remote._getDeviceSupportsTokens({
             'device': {
               'FrameTVSupport': 'false',
               'GamePadSupport': 'true',
@@ -451,7 +451,7 @@ describe('TizenRemote', function () {
           expect(r, 'to equal', 'false');
         });
         it('should null', function () {
-          const r = remote._getTokenSupportDevice({
+          const r = remote._getDeviceSupportsTokens({
             'device': {
               'FrameTVSupport': 'false',
               'GamePadSupport': 'true',


### PR DESCRIPTION
- Do not raise an error while no app found in driver.js for older TVs
- Add `isTokenSupportedDevice` to check if the device supports token
- Modify pair's log message
- Prevent raising exception for non-token response by the device for old TVs (e.g. Year 2016 model)