### PR TITLE
feat: improve older platform version handling such as 2016

### DIFF
--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -53,9 +53,11 @@ package in your `package.json`)
     One possible reason here is this pairing request was denied in the past. Please check if such a "denied" item exists in the device list below.
     Then, please re-run the `pair-remote` command.
     - Go to _Settings_ -> _General_ -> _External Device Manager_ -> _Device Connect Manager_ -> _Device List_ and delete the "denied" item. (This device list place could depend on TV kinds)
-- WebKit based Tizen TV model does not support chromedriver automation. Please use `'appium:rcMode':'remote'`. Then, the session will work as rcOnly mode.
-  - Tizen 2.4 (2016) and lower versions in [Web Engine Specifications](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html) have WebKit engine, which does not support toolchains for Chromium.
 
+## Known limitations
+
+- WebKit based Tizen TV models (Tizen 2.4 (2016) and lower versions) do not support chromedriver based automation. Please use `'appium:rcMode':'remote'`. Then, the session will work as rcOnly mode.
+  -  Reference: [Web Engine Specifications](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html)
 
 ## Capabilities
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -53,6 +53,9 @@ package in your `package.json`)
     One possible reason here is this pairing request was denied in the past. Please check if such a "denied" item exists in the device list below.
     Then, please re-run the `pair-remote` command.
     - Go to _Settings_ -> _General_ -> _External Device Manager_ -> _Device Connect Manager_ -> _Device List_ and delete the "denied" item. (This device list place could depend on TV kinds)
+- WebKit based Tizen TV model does not support chromedriver automation. Please use `'appium:rcMode':'remote'`. Then, the session will work as rcOnly mode.
+  - Tizen 2.4 (2016) and lower version in [Web Engine Specifications](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html). Then, the automation will forcefully be `rcOnly` mode.
+
 
 ## Capabilities
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -54,7 +54,7 @@ package in your `package.json`)
     Then, please re-run the `pair-remote` command.
     - Go to _Settings_ -> _General_ -> _External Device Manager_ -> _Device Connect Manager_ -> _Device List_ and delete the "denied" item. (This device list place could depend on TV kinds)
 - WebKit based Tizen TV model does not support chromedriver automation. Please use `'appium:rcMode':'remote'`. Then, the session will work as rcOnly mode.
-  - Tizen 2.4 (2016) and lower version in [Web Engine Specifications](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html). Then, the automation will forcefully be `rcOnly` mode.
+  - Tizen 2.4 (2016) and lower versions in [Web Engine Specifications](https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html) have WebKit engine, which does not support toolchains for Chromium.
 
 
 ## Capabilities

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -11,6 +11,8 @@ const WAIT_TIME = '30';
 
 /**
  * sdb shell debug command has different format lower/bigger than this version.
+ * At least 3.0.0 and 2.5.0 should be `shell 0 debug <app> <number>`,
+ * 5.0 and newer should be `shell 0 debug <app> <number>`.
  */
 const PLATFORM_VERSION_COMMAND_COMPATIBILITY = '4.0.0';
 
@@ -33,7 +35,7 @@ async function runSDBCmd(udid, args) {
 function _buildDebugCommand(platformVersion, appPackage) {
   const cmd = ['shell', '0', 'debug', appPackage];
   if (util.compareVersions(platformVersion, '<', PLATFORM_VERSION_COMMAND_COMPATIBILITY)) {
-    // this WAIT_TIME_SEC is maybe seconds, or it could be attempt count.
+    // this WAIT_TIME is maybe in seconds, or it could be attempt count.
     cmd.push(WAIT_TIME);
   }
   return cmd;

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -3,7 +3,7 @@ import {runCmd, SDB_BIN_NAME} from './helpers';
 import {util} from 'appium/support';
 import _ from 'lodash';
 
-const DEBUG_PORT_RE = /^(?:.*port:\s)(?<port>\d{1,5})$/;
+const DEBUG_PORT_RE = /^(?:.*port:\s)(?<port>\d{1,5}).*/;
 const APP_LIST_RE = /^[^']*'(?<name>[^']*)'[^']+'(?<id>[^']+)'\s*$/;
 
 const WAIT_TIME = '30';
@@ -32,6 +32,15 @@ function buildDebugCommand(platformVersion, appPackage) {
 }
 
 /**
+ *
+ * @param {*} stdout
+ * @returns
+ */
+function parseDebugPort(stdout) {
+  return stdout.trim().match(DEBUG_PORT_RE)?.groups?.port;
+}
+
+/**
  * @param {import('type-fest').SetRequired<Pick<StrictTizenTVDriverCaps, 'appPackage'|'udid'>, 'appPackage'>} caps
  * @param {string|number} platformVersion Platform version info available via `sdb capability` command
  */
@@ -39,7 +48,7 @@ async function debugApp({appPackage, udid}, platformVersion) {
   log.info(`Starting ${appPackage} in debug mode on ${udid}`);
   const {stdout} = await runSDBCmd(udid, buildDebugCommand(`${platformVersion}`, appPackage));
   try {
-    const port = stdout.trim().match(DEBUG_PORT_RE)?.groups?.port;
+    const port = parseDebugPort(stdout);
     if (!port) {
       throw new Error(`Cannot parse debug port from sdb output`);
     }
@@ -147,7 +156,8 @@ export {
   connectDevice,
   disconnectDevice,
   removeForwardedPort,
-  buildDebugCommand
+  buildDebugCommand,
+  parseDebugPort
 };
 
 /**

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -31,10 +31,12 @@ async function runSDBCmd(udid, args) {
  * @returns {Array<string>}
  */
 function _buildDebugCommand(platformVersion, appPackage) {
-  return util.compareVersions(platformVersion, '<', PLATFORM_VERSION_COMMAND_COMPATIBILITY)
+  const cmd = ['shell', '0', 'debug', appPackage];
+  if (util.compareVersions(platformVersion, '<', PLATFORM_VERSION_COMMAND_COMPATIBILITY)) {
     // this WAIT_TIME_SEC is maybe seconds, or it could be attempt count.
-    ? ['shell', '0', 'debug', appPackage, WAIT_TIME]
-    : ['shell', '0', 'debug', appPackage];
+    cmd.push(WAIT_TIME);
+  }
+  return cmd;
 }
 
 /**

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -20,6 +20,7 @@ import {desiredCapConstraints} from './desired-caps';
 import {getKeyData, isRcKeyCode} from './keymap';
 import log from './logger';
 import {AsyncScripts, SyncScripts} from './scripts';
+import { util } from 'appium/support';
 
 const BROWSER_APP_ID = 'org.tizen.browser';
 const GALLERY_APP_ID = 'com.samsung.tv.gallery';
@@ -281,6 +282,20 @@ class TizenTVDriver extends BaseDriver {
       log.info(`The rcMode capability was not set to remote but we are in rcOnly mode, so ` +
                `forcing it to remote`);
       caps.rcMode = this.opts.rcMode = RC_MODE_REMOTE;
+    }
+
+    if (caps.rcMode !== RC_MODE_REMOTE && util.compareVersions(this.#platformVersion, '<', '3')) {
+    }
+
+    if (util.compareVersions(this.#platformVersion, '<', '3')) {
+      if (caps.rcMode === RC_MODE_REMOTE) {
+        log.info(`The ${this.opts.udid} Tizen platform version support only rcOnly mode.`);
+        caps.rcOnly = true;
+      } else {
+        throw new errors.SessionNotCreatedError(
+          `Tizen ${this.#platformVersion} needs to be 'remote' mode for 'rcMode'.`
+        )
+      }
     }
 
     // XXX: remote setup _may_ need to happen after the power-cycling business below.

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -289,7 +289,7 @@ class TizenTVDriver extends BaseDriver {
     // At least tizen tv platform 2.5 and lower should support rcMode only.
     if (util.compareVersions(this.#platformVersion, '<', '3')) {
       if (caps.rcMode === RC_MODE_REMOTE) {
-        log.info(`The ${this.opts.udid} Tizen platform version support only rcOnly mode.`);
+        log.info(`The ${this.opts.udid} Tizen platform version supports only rcOnly mode.`);
         caps.rcOnly = true;
       } else {
         throw new errors.SessionNotCreatedError(

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -275,9 +275,9 @@ class TizenTVDriver extends BaseDriver {
     this.#platformVersion = deviceCaps?.platform_version || DEFAULT_PLATFORM_VERSION;
     // @ts-ignore
     if (deviceCaps?.platform_version) {
-      log.info(`The ${this.opts.udid} Tizen platform version is ${this.#platformVersion}`);
+      log.info(`The Tizen platform version is ${this.#platformVersion}`);
     } else {
-      log.info(`The ${this.opts.udid} Tizen platform version is unknown. Using ${DEFAULT_PLATFORM_VERSION}.`);
+      log.info(`The Tizen platform version is unknown. Using ${DEFAULT_PLATFORM_VERSION}.`);
     }
 
     if (caps.rcOnly && caps.rcMode !== RC_MODE_REMOTE) {

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -277,7 +277,7 @@ class TizenTVDriver extends BaseDriver {
     if (deviceCaps?.platform_version) {
       log.info(`The Tizen platform version is ${this.#platformVersion}`);
     } else {
-      log.info(`The Tizen platform version is unknown. Using ${DEFAULT_PLATFORM_VERSION}.`);
+      log.info(`The Tizen platform version is unknown, using ${DEFAULT_PLATFORM_VERSION} as preset version.`);
     }
 
     if (caps.rcOnly && caps.rcMode !== RC_MODE_REMOTE) {
@@ -286,14 +286,15 @@ class TizenTVDriver extends BaseDriver {
       caps.rcMode = this.opts.rcMode = RC_MODE_REMOTE;
     }
 
-    // At least platform 2.5 and lower should be rcMode only.
+    // At least tizen tv platform 2.5 and lower should support rcMode only.
     if (util.compareVersions(this.#platformVersion, '<', '3')) {
       if (caps.rcMode === RC_MODE_REMOTE) {
         log.info(`The ${this.opts.udid} Tizen platform version support only rcOnly mode.`);
         caps.rcOnly = true;
       } else {
         throw new errors.SessionNotCreatedError(
-          `Tizen ${this.#platformVersion} needs to be 'remote' mode for 'rcMode'.`
+          `The session needs to be 'appium:rcMode': 'remote' because the Tizen ${this.#platformVersion} version ` +
+            `is WebKit based engine. It does not work for Chromium based toolchains like WebInspector and chromedriver.`
         );
       }
     }

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -296,7 +296,7 @@ class TizenTVDriver extends BaseDriver {
       } else {
         throw new errors.SessionNotCreatedError(
           `Tizen ${this.#platformVersion} needs to be 'remote' mode for 'rcMode'.`
-        )
+        );
       }
     }
 

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -286,9 +286,7 @@ class TizenTVDriver extends BaseDriver {
       caps.rcMode = this.opts.rcMode = RC_MODE_REMOTE;
     }
 
-    if (caps.rcMode !== RC_MODE_REMOTE && util.compareVersions(this.#platformVersion, '<', '3')) {
-    }
-
+    // At least platform 2.5 and lower should be rcMode only.
     if (util.compareVersions(this.#platformVersion, '<', '3')) {
       if (caps.rcMode === RC_MODE_REMOTE) {
         log.info(`The ${this.opts.udid} Tizen platform version support only rcOnly mode.`);

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -271,7 +271,9 @@ class TizenTVDriver extends BaseDriver {
 
     // Raise an error if the `sdb capabilities` might raise an exception
     const deviceCaps = await deviceCapabilities({udid: this.opts.udid});
+    // @ts-ignore
     this.#platformVersion = deviceCaps?.platform_version || DEFAULT_PLATFORM_VERSION;
+    // @ts-ignore
     if (deviceCaps?.platform_version) {
       log.info(`The ${this.opts.udid} Tizen platform version is ${this.#platformVersion}`);
     } else {

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -1,6 +1,6 @@
 import unexpected from 'unexpected';
 import unexpectedSinon from 'unexpected-sinon';
-import {_parseListAppsCmd, buildDebugCommand, parseDebugPort} from '../../lib/cli/sdb';
+import {_parseListAppsCmd, _buildDebugCommand, _parseDebugPort, _parseCapability} from '../../lib/cli/sdb';
 
 const expect = unexpected.clone().use(unexpectedSinon);
 
@@ -14,7 +14,7 @@ describe('sdb', function () {
         '4.0.0.0'
       ]) {
         expect(
-          buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper']
+          _buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper']
         );
       }
     });
@@ -26,7 +26,7 @@ describe('sdb', function () {
         '3.5.9.9'
       ]) {
         expect(
-          buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper', '30']
+          _buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper', '30']
         );
       }
     });
@@ -36,24 +36,95 @@ describe('sdb', function () {
     it('should parse the version as zero', function () {
       const stdout = 'port: 0\r\n\tresult: launched\r\n';
       expect(
-        parseDebugPort(stdout), 'to equal', '0'
+        _parseDebugPort(stdout), 'to equal', '0'
       );
     });
 
     it('should parse the version as non-zero', function () {
       const stdout = 'port: 44670\r\n\tresult: launched\r\n';
       expect(
-        parseDebugPort(stdout), 'to equal', '44670'
+        _parseDebugPort(stdout), 'to equal', '44670'
       );
     });
 
     it('should parse the version for platform version 4 or newer', function () {
       const stdout = '... successfully launched pid = 32003 with debug 1 port: 44670';
       expect(
-        parseDebugPort(stdout), 'to equal', '44670'
+        _parseDebugPort(stdout), 'to equal', '44670'
       );
     });
   });
+
+
+  describe('_parseCapability', function () {
+    it('newer device', function () {
+      const stdout = `
+secure_protocol:enabled
+intershell_support:disabled
+filesync_support:pushpull
+usbproto_support:disabled
+sockproto_support:enabled
+syncwinsz_support:enabled
+sdbd_rootperm:disabled
+rootonoff_support:disabled
+encryption_support:disabled
+zone_support:disabled
+multiuser_support:enabled
+cpu_arch:armv7
+sdk_toolpath:/home/owner/share/tmp/sdk_tools
+profile_name:tv
+vendor_name:Samsung
+can_launch:tv-samsung
+device_name:Tizen
+platform_version:5.0
+product_version:4.0
+sdbd_version:2.2.31
+sdbd_plugin_version:3.7.1_TV_REL
+sdbd_cap_version:1.0
+log_enable:disabled
+log_path:/tmp
+appcmd_support:disabled
+appid2pid_support:enabled
+pkgcmd_debugmode:enabled
+netcoredbg_support:enabled`;
+
+      const parsedResult = _parseCapability(stdout);
+      expect(
+        parsedResult, 'to equal', {
+          secure_protocol: 'enabled',
+          intershell_support: 'disabled',
+          filesync_support: 'pushpull',
+          usbproto_support: 'disabled',
+          sockproto_support: 'enabled',
+          syncwinsz_support: 'enabled',
+          sdbd_rootperm: 'disabled',
+          rootonoff_support: 'disabled',
+          encryption_support: 'disabled',
+          zone_support: 'disabled',
+          multiuser_support: 'enabled',
+          cpu_arch: 'armv7',
+          sdk_toolpath: '/home/owner/share/tmp/sdk_tools',
+          profile_name: 'tv',
+          vendor_name: 'Samsung',
+          can_launch: 'tv-samsung',
+          device_name: 'Tizen',
+          platform_version: '5.0',
+          product_version: '4.0',
+          sdbd_version: '2.2.31',
+          sdbd_plugin_version: '3.7.1_TV_REL',
+          sdbd_cap_version: '1.0',
+          log_enable: 'disabled',
+          log_path: '/tmp',
+          appcmd_support: 'disabled',
+          appid2pid_support: 'enabled',
+          pkgcmd_debugmode: 'enabled',
+          netcoredbg_support: 'enabled'
+        }
+      );
+      expect(parsedResult.platform_version, 'to equal', '5.0');
+    });
+  });
+
 
   describe('_parseListAppsCmd', function () {
     it('should return the list of apps', function () {

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -57,7 +57,7 @@ describe('sdb', function () {
 
 
   describe('_parseCapability', function () {
-    it('newer device', function () {
+    it('newer device, platform 5.0', function () {
       const stdout = `
 secure_protocol:enabled
 intershell_support:disabled
@@ -119,6 +119,52 @@ netcoredbg_support:enabled`;
           appid2pid_support: 'enabled',
           pkgcmd_debugmode: 'enabled',
           netcoredbg_support: 'enabled'
+        }
+      );
+      expect(parsedResult.platform_version, 'to equal', '5.0');
+    });
+    it('old device, platform 2.4', function () {
+      const stdout = `
+secure_protocol:enabled
+intershell_support:disabled
+filesync_support:push
+usbproto_support:enabled
+sockproto_support:enabled
+syncwinsz_support:enabled
+rootonoff_support:disabled
+zone_support:disabled
+multiuser_support:disabled
+cpu_arch:armv7
+profile_name:tv
+vendor_name:Samsung
+can_launch:tv-samsung-public_-_tv-samsung-partner
+platform_version:2.4.0
+product_version:2.0
+sdbd_version:2.2.31
+sdbd_plugin_version:1.0.0
+sdbd_cap_version:1.0`;
+
+      const parsedResult = _parseCapability(stdout);
+      expect(
+        parsedResult, 'to equal', {
+          secure_protocol: 'enabled',
+          intershell_support: 'disabled',
+          filesync_support: 'push',
+          usbproto_support: 'enabled',
+          sockproto_support: 'enabled',
+          syncwinsz_support: 'enabled',
+          rootonoff_support: 'disabled',
+          zone_support: 'disabled',
+          multiuser_support: 'disabled',
+          cpu_arch: 'armv7',
+          profile_name: 'tv',
+          vendor_name: 'Samsung',
+          can_launch: 'tv-samsung-public_-_tv-samsung-partner',
+          platform_version: '2.4.0',
+          product_version: '2.0',
+          sdbd_version: '2.2.31',
+          sdbd_plugin_version: '1.0.0',
+          sdbd_cap_version: '1.0'
         }
       );
       expect(parsedResult.platform_version, 'to equal', '5.0');

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -1,6 +1,6 @@
 import unexpected from 'unexpected';
 import unexpectedSinon from 'unexpected-sinon';
-import {_parseListAppsCmd, buildDebugCommand} from '../../lib/cli/sdb';
+import {_parseListAppsCmd, buildDebugCommand, parseDebugPort} from '../../lib/cli/sdb';
 
 const expect = unexpected.clone().use(unexpectedSinon);
 
@@ -29,6 +29,29 @@ describe('sdb', function () {
           buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper', '30']
         );
       }
+    });
+  });
+
+  describe('parseDebugPort', function () {
+    it('should parse the version as zero', function () {
+      const stdout = 'port: 0\r\n\tresult: launched\r\n';
+      expect(
+        parseDebugPort(stdout), 'to equal', '0'
+      );
+    });
+
+    it('should parse the version as non-zero', function () {
+      const stdout = 'port: 44670\r\n\tresult: launched\r\n';
+      expect(
+        parseDebugPort(stdout), 'to equal', '44670'
+      );
+    });
+
+    it('should parse the version for platform version 4 or newer', function () {
+      const stdout = '... successfully launched pid = 32003 with debug 1 port: 44670';
+      expect(
+        parseDebugPort(stdout), 'to equal', '44670'
+      );
     });
   });
 

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -166,7 +166,7 @@ sdbd_cap_version:1.0`;
           sdbd_cap_version: '1.0'
         }
       );
-      expect(parsedResult.platform_version, 'to equal', '5.0');
+      expect(parsedResult.platform_version, 'to equal', '2.4.0');
     });
   });
 

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -55,7 +55,6 @@ describe('sdb', function () {
     });
   });
 
-
   describe('_parseCapability', function () {
     it('newer device, platform 5.0', function () {
       const stdout = `
@@ -170,7 +169,6 @@ sdbd_cap_version:1.0`;
       expect(parsedResult.platform_version, 'to equal', '5.0');
     });
   });
-
 
   describe('_parseListAppsCmd', function () {
     it('should return the list of apps', function () {

--- a/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/sdb.spec.js
@@ -1,10 +1,37 @@
 import unexpected from 'unexpected';
 import unexpectedSinon from 'unexpected-sinon';
-import {_parseListAppsCmd} from '../../lib/cli/sdb';
+import {_parseListAppsCmd, buildDebugCommand} from '../../lib/cli/sdb';
 
 const expect = unexpected.clone().use(unexpectedSinon);
 
 describe('sdb', function () {
+  describe('buildDebugCommand', function () {
+    it('should for newer platform version', function () {
+      for (const platformVersion of [
+        '4',
+        '4.0',
+        '4.0.0',
+        '4.0.0.0'
+      ]) {
+        expect(
+          buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper']
+        );
+      }
+    });
+    it('should for older platform version', function () {
+      for (const platformVersion of [
+        '3',
+        '3.5',
+        '3.5.9',
+        '3.5.9.9'
+      ]) {
+        expect(
+          buildDebugCommand(platformVersion, 'biF5E2SN9M.AppiumHelper'), 'to equal', ['shell', '0', 'debug', 'biF5E2SN9M.AppiumHelper', '30']
+        );
+      }
+    });
+  });
+
   describe('_parseListAppsCmd', function () {
     it('should return the list of apps', function () {
       const returnValue = "\tApplication List for user 5001\r\n\tUser's Application \r\n\t Name \t AppID \r\n\t=================================================\r\n\t'alexa-fullscreen-app'\t 'com.samsung.tv.alexa-client-xapp-ut-on-tv'\r\n\t'ContentSharing.Provider.Ftp'\t 'com.samsung.tv.coss.provider.d2d'\r\n\t'Xbox'\t 'GHI3a0zMSx.XboxGamePass'\r\n\t'cloning'\t 'org.tizen.cloning'\r\n\t'csfs'\t 'com.samsung.tv.csfs'\r\n\t'あ'\t 'pIaMf8YZyZ.service'\r\n\t'service-application'\t 'org.tizen.was-appsync'\r\n\t'fuzzy-search-engine'\t 'com.samsung.tv.fuzzy-search-engine'\r\n\t'pisa-control-service'\t 'org.tizen.pisa-control-service'\r\n\t'SmartThings Home CCTV Service'\t 'com.samsung.tv.iot-service-home-cctv_FLUX'\r\n\t'samsung-pass'\t 'com.samsung.tizen.samsung-pass-agent'\r\n\t'pluginplatform'\t 'com.samsung.tizen.smartthings-plugin-platform'\r\n\t'LibAriaFW'\t 'lib-ariafw-tv'\r\n\t'com.samsung.tv.ondevice-voice'\t 'com.samsung.tv.ondevice-voice'\r\n\t'PBS Video'\t '70fRFUwYlD.OtterGAProd'\r\n\t'iacr'\t 'com.samsung.tv.iacr'\r\n\t'Samsung Health'\t 'com.samsung.tv.samsung-health'\r\n\t''\t 'com.samsung.tv.remoteapp.local_stream'\r\n\t=================================================\r\n";


### PR DESCRIPTION
I learned

- tizen 2.5 and lower platform may not support chromedriver automation because of  the engine matter https://developer.samsung.com/smarttv/develop/specifications/web-engine-specifications.html
- `debug` command syntax could depend on the platform version


So, this PR does

1. not support JS mode (chromedriver automation) for lower than 2.4 tizentv platform version as imcompatibility. Instead, if the given caps uses `remote` mode, the session will work `rcOnly` mode
2. modify `debug` command syntax for 4.0+ or lower than 4.0.



Possibly this will close https://github.com/headspinio/appium-tizen-tv-driver/issues/584 also. This PR helps https://github.com/headspinio/appium-tizen-tv-driver/issues/548 as well.