### PR TITLE
feat: add activateApp/terminateApp ext command

### DIFF
--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -159,9 +159,23 @@ Refer to your Appium client library for how to use this method.
 
 - `script`: `tizen: listApps`
 
+### Activate the application package
+
+> Send launch command with the given package name.
+> This package name is the same as what you give as `appium:appPackage`.
+> Note that this command does not start the package with debug mode.
+> Chromedriver automation will not start against this device.
+
+- `POST /session/:sessionId/execute`
+
+#### Arguments
+
+- `script`: `tizen: activateApp`
+- `appPackage`: application package name to launch
+
 ### Terminate the package id
 
-> Send kill command to the given package id.
+> Send kill command with the given package id.
 > This package id is not entire `appPackage`.
 > It could be the same as the `appPackage`, but it also could be different.
 > e.g. `org.tizen.browser` works both `appPackage` and `pkgId`, but `9Ur5IzDKqV.TizenYouTube` works as `appPackage` but the `9Ur5IzDKqV` part is `pkgId`.
@@ -171,7 +185,7 @@ Refer to your Appium client library for how to use this method.
 #### Arguments
 
 - `script`: `tizen: terminateApp`
-- `pkgId`: package id
+- `pkgId`: package id to terminate
 
 ### Proxied Commands
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -159,6 +159,19 @@ Refer to your Appium client library for how to use this method.
 
 - `script`: `tizen: listApps`
 
+### Terminate the package id
+
+> Send kill command to the given package id.
+> This package id is not entire `appPackage`.
+> It could be the same as the `appPackage`, but it also could be different.
+> e.g. `org.tizen.browser` works both `appPackage` and `pkgId`, but `9Ur5IzDKqV.TizenYouTube` works as `appPackage` but the `9Ur5IzDKqV` part is `pkgId`.
+
+- `POST /session/:sessionId/execute`
+
+#### Arguments
+
+- `script`: `tizen: terminateApp`
+- `pkgId`: package id
 
 ### Proxied Commands
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -159,12 +159,12 @@ Refer to your Appium client library for how to use this method.
 
 - `script`: `tizen: listApps`
 
-### Activate the application package
+### Activate the package name
 
-> Send launch command with the given package name.
+> Send launch command with the given package name to the device under test.
 > This package name is the same as what you give as `appium:appPackage`.
 > Note that this command does not start the package with debug mode.
-> Chromedriver automation will not start against this device.
+> Chromedriver automation will not start against the package name.
 
 - `POST /session/:sessionId/execute`
 
@@ -175,10 +175,11 @@ Refer to your Appium client library for how to use this method.
 
 ### Terminate the package id
 
-> Send kill command with the given package id.
+> Send kill command with the given package id to the device under test.
 > This package id is not entire `appPackage`.
 > It could be the same as the `appPackage`, but it also could be different.
-> e.g. `org.tizen.browser` works both `appPackage` and `pkgId`, but `9Ur5IzDKqV.TizenYouTube` works as `appPackage` but the `9Ur5IzDKqV` part is `pkgId`.
+> Please check the `pkgId` value in your application under test package.
+> e.g. `org.tizen.browser` works both `appPackage` and `pkgId`, but `9Ur5IzDKqV.TizenYouTube` works as `appPackage` but the `9Ur5IzDKqV` part is `pkgId` used in this command.
 
 - `POST /session/:sessionId/execute`
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -150,7 +150,7 @@ Refer to your Appium client library for how to use this method.
 
 ### Get the list of installed applications
 
-> The list of installed applications. Old device models (e.g. Year 2016) may return always an empty list as not supported.
+> The list of installed applications. Old device models (e.g. Year 2016) may always return an empty list as not supported.
 > Each item has `appName` and `appPackage`.
 
 - `POST /session/:sessionId/execute`
@@ -161,7 +161,7 @@ Refer to your Appium client library for how to use this method.
 
 ### Activate the package name
 
-> Send launch command with the given package name to the device under test.
+> Send a launch command with the given package name to the device under test.
 > This package name is the same as what you give as `appium:appPackage`.
 > Note that this command does not start the package with debug mode.
 > Chromedriver automation will not start against the package name.
@@ -175,8 +175,8 @@ Refer to your Appium client library for how to use this method.
 
 ### Terminate the package id
 
-> Send kill command with the given package id to the device under test.
-> This package id is not entire `appPackage`.
+> Send a kill command with the given package id to the device under test.
+> This package id is not the entire `appPackage`.
 > It could be the same as the `appPackage`, but it also could be different.
 > Please check the `pkgId` value in your application under test package.
 > e.g. `org.tizen.browser` works both `appPackage` and `pkgId`, but `9Ur5IzDKqV.TizenYouTube` works as `appPackage` but the `9Ur5IzDKqV` part is `pkgId` used in this command.

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -50,6 +50,22 @@ async function launchApp({appPackage, udid}) {
 }
 
 /**
+ * Launch (but do not attempt to debug) an app on the TV
+ *
+ * @param {import('type-fest').SetRequired<Pick<StrictTizenTVDriverCaps, 'udid'>, 'udid'>} caps
+ * @param {string} pkgId package id to kill the process.
+ */
+async function terminateApp({udid}, pkgId) {
+  log.info(`Terminating ${pkgId} in on ${udid}`);
+  const {stdout} = await runSDBCmd(udid, ['shell', '0', 'kill', pkgId]);
+  if (/is already Terminated/.test(stdout)) {
+    return;
+  }
+  throw new Error(`Could not terminate app. Please make sure if the given '${pkgId}' was correct package id. Stdout from kill call was: ${stdout}`);
+}
+
+
+/**
  * Return the list of installed applications with the pair of
  * an application name and the package name.
  * @param {Pick<StrictTizenTVDriverCaps, 'udid'>} caps
@@ -122,6 +138,7 @@ export {
   runSDBCmd,
   debugApp,
   launchApp,
+  terminateApp,
   listApps,
   _parseListAppsCmd,
   forwardPort,

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -58,10 +58,9 @@ async function launchApp({appPackage, udid}) {
 async function terminateApp({udid}, pkgId) {
   log.info(`Terminating ${pkgId} in on ${udid}`);
   const {stdout} = await runSDBCmd(udid, ['shell', '0', 'kill', pkgId]);
-  if (/is already Terminated/.test(stdout)) {
-    return;
+  if (/failed/.test(stdout)) {
+    throw new Error(`Could not terminate app. Please make sure if the given '${pkgId}' was correct package id. Stdout from kill call was: ${stdout}`);
   }
-  throw new Error(`Could not terminate app. Please make sure if the given '${pkgId}' was correct package id. Stdout from kill call was: ${stdout}`);
 }
 
 

--- a/packages/appium-tizen-tv-driver/lib/cli/sdb.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/sdb.js
@@ -58,7 +58,7 @@ async function launchApp({appPackage, udid}) {
 async function terminateApp({udid}, pkgId) {
   log.info(`Terminating ${pkgId} in on ${udid}`);
   const {stdout} = await runSDBCmd(udid, ['shell', '0', 'kill', pkgId]);
-  if (/failed/.test(stdout)) {
+  if (/failed/i.test(stdout)) {
     throw new Error(`Could not terminate app. Please make sure if the given '${pkgId}' was correct package id. Stdout from kill call was: ${stdout}`);
   }
 }

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -12,6 +12,7 @@ import {
   disconnectDevice,
   forwardPort,
   listApps,
+  terminateApp,
   removeForwardedPort,
 } from './cli/sdb';
 import {tizenInstall, tizenRun, tizenUninstall} from './cli/tizen';
@@ -148,6 +149,12 @@ class TizenTVDriver extends BaseDriver {
       command: 'tizentvListApps',
       params: {},
     }),
+
+    'tizen: terminateApp': Object.freeze({
+      command: 'tizentvTerminateApp',
+      params: {required: ['pkgId']},
+    }),
+
   });
 
   /** @type {TizenRemote|undefined} */
@@ -781,6 +788,15 @@ class TizenTVDriver extends BaseDriver {
    */
   async tizentvListApps() {
     return await listApps({udid: this.opts.udid});
+  }
+
+  /**
+   * Terminate the given app package id.
+   * @param {string} pkgId
+   * @returns
+   */
+  async tizentvTerminateApp(pkgId) {
+    return await terminateApp({udid: this.opts.udid}, pkgId)
   }
 }
 

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -13,6 +13,7 @@ import {
   forwardPort,
   listApps,
   terminateApp,
+  launchApp,
   removeForwardedPort,
 } from './cli/sdb';
 import {tizenInstall, tizenRun, tizenUninstall} from './cli/tizen';
@@ -149,7 +150,10 @@ class TizenTVDriver extends BaseDriver {
       command: 'tizentvListApps',
       params: {},
     }),
-
+    'tizen: activateApp': Object.freeze({
+      command: 'tizentvActivateApp',
+      params: {required: ['appPackage']},
+    }),
     'tizen: terminateApp': Object.freeze({
       command: 'tizentvTerminateApp',
       params: {required: ['pkgId']},
@@ -789,6 +793,16 @@ class TizenTVDriver extends BaseDriver {
    */
   async tizentvListApps() {
     return await listApps({udid: this.opts.udid});
+  }
+
+
+  /**
+   * Launch the given appPackage. The process won't start as a debug mode.
+   * @param {string} appPackage
+   * @returns
+   */
+  async tizentvActivateApp(appPackage) {
+    return await launchApp({appPackage, udid: this.opts.udid});
   }
 
   /**

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -796,7 +796,7 @@ class TizenTVDriver extends BaseDriver {
    * @returns
    */
   async tizentvTerminateApp(pkgId) {
-    return await terminateApp({udid: this.opts.udid}, pkgId)
+    return await terminateApp({udid: this.opts.udid}, pkgId);
   }
 }
 


### PR DESCRIPTION
closes https://github.com/headspinio/appium-tizen-tv-driver/issues/601

Ideally, we'd like to terminate the app under test with this command before launching the app to avoid no response by `tizen run` / `sdb shell was_execute` command