### PR TITLE
chore: add better logging/error handling for tizen command

### DIFF
--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -186,6 +186,7 @@ npm run watch
     - Perhaps the TV device internal is weird state to launch the app process.
 - App uninstallation could fail silently. It means while tizen/shell command did not end with exit code non-zero, the command failed to uninstall the app.
     - Please manually uninstall the application if you'd like to uninstall completely.
+    - Report this issue in [bug report](https://www.tizen.org/ko/community/bug-tracker/how-report-bugs)
 
 ## Credits
 

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -184,7 +184,8 @@ npm run watch
 - The application under test keeps raising an error succh as `Could not launch the null application` (as part of the error message)
     - Please specify `appium:app` capability. Then usually tizentv driver uninstalls the app before installing the app to terminate the running app process forcefully.
     - Perhaps the TV device internal is weird state to launch the app process.
-
+- App uninstallation could fail silently. It means while tizen/shell command did not end with exit code non-zero, the command failed to uninstall the app.
+    - Please manually uninstall the application if you'd like to uninstall completely.
 
 ## Credits
 

--- a/packages/appium-tizen-tv-driver/lib/cli/tizen.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/tizen.js
@@ -13,15 +13,84 @@ async function runTizenCmd(args) {
  */
 async function tizenInstall({app, udid}) {
   log.info(`Installing tizen app '${app}' on device '${udid}'`);
-  return await runTizenCmd(['install', '-n', app, '-s', udid]);
+
+  // $ tizen install -t biF5E2SN9M.AppiumHelper  -n /path/to/AppiumHelper.wgt -s <device>
+  // Transferring the package...
+  // Transferred the package: /path/to/AppiumHelper.wgt -> /home/owner/share/tmp/sdk_tools/tmp
+  // Installing the package...
+  // --------------------
+  // Platform log view
+  // --------------------
+  // install biF5E2SN9M.AppiumHelper
+  // package_path /home/owner/share/tmp/sdk_tools/tmp/AppiumHelper.wgt
+  // was_install_app return WAS_TRUE
+  // app_id[biF5E2SN9M.AppiumHelper] install start
+  // app_id[biF5E2SN9M.AppiumHelper] installing[8]
+  // ..
+  // app_id[biF5E2SN9M.AppiumHelper] installing[95]
+  // app_id[biF5E2SN9M.AppiumHelper] installing[97]
+  // app_id[biF5E2SN9M.AppiumHelper] installing[100]
+  // app_id[biF5E2SN9M.AppiumHelper] install completed
+  // spend time for wascmd is [2520]ms
+  // cmd_ret:0
+  // Installed the package: Id(biF5E2SN9M.AppiumHelper)
+  // Tizen application is successfully installed.
+  // Total time: 00:00:02.995
+
+  // If an error occurred in the installation command, it will raise an error as well.
+  // e.g. Different signature app is already installed.
+  const {stdout} = await runTizenCmd(['install', '-n', app, '-s', udid]);
+  if (/successfully/.test(stdout)) {
+    throw new Error(`Could not install app ${app}. Stdout from install call was: ${stdout}`);
+  }
 }
 
 /**
+ * Uninstall the given app package from the udid.
+ * Raises an error in case tizen command raises exit non-zero code, or
+ * the tizen command silently failed with exit code 0.
+ *
  * @param {import('type-fest').SetRequired<Pick<StrictTizenTVDriverCaps, 'appPackage'|'udid'>, 'appPackage'>} caps
  */
 async function tizenUninstall({appPackage, udid}) {
   log.info(`Uninstalling tizen app '${appPackage}' on device '${udid}'`);
-  return await runTizenCmd(['uninstall', '-p', appPackage, '-s', udid]);
+
+  // $ tizen uninstall -p biF5E2SN9M.AppiumHelper -s <device>
+  // --------------------
+  // Platform log view
+  // --------------------
+  // uninstall biF5E2SN9M.AppiumHelper
+  // app_id[biF5E2SN9M.AppiumHelper] uninstall start
+  // app_id[biF5E2SN9M.AppiumHelper] uninstalling[14]
+  // app_id[biF5E2SN9M.AppiumHelper] uninstalling[57]
+  // app_id[biF5E2SN9M.AppiumHelper] uninstall completed
+  // spend time for wascmd is [7776]ms
+  // cmd_ret:0
+  // Total time: 00:00:08.691
+  //
+  // or
+  // $ tizen uninstall -p biF5E2SN9M.AppiumHelper -s <device>
+  // Package ID is not valid. Please check the package ID again.
+  // Total time: 00:00:00.646
+  //
+  // or (silently failed.)
+  // $ tizen uninstall -p biF5E2SN9M.AppiumHelper -s <device>
+  // --------------------
+  // Platform log view
+  // --------------------
+  // Total time: 00:00:00.324
+
+  const {stdout} = await runTizenCmd(['uninstall', '-p', appPackage, '-s', udid]);
+  if (/uninstall completed/.test(stdout)) {
+    // ok
+    return;
+  }
+  if (/Package ID is not valid/.test(stdout)) {
+    // This case could indicate the app does not exist. Ignoring.
+    return;
+  }
+
+  throw new Error(`Might fail to uninstall ${appPackage}. Stdout from uninstall call was: ${stdout}`);
 }
 
 /**

--- a/packages/appium-tizen-tv-driver/lib/cli/tizen.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/tizen.js
@@ -40,7 +40,7 @@ async function tizenInstall({app, udid}) {
   // If an error occurred in the installation command, it will raise an error as well.
   // e.g. Different signature app is already installed.
   const {stdout} = await runTizenCmd(['install', '-n', app, '-s', udid]);
-  if (/successfully/.test(stdout)) {
+  if (/successfully/i.test(stdout)) {
     return;
   }
   throw new Error(`Could not install app ${app}. Stdout from install call was: ${stdout}`);
@@ -82,11 +82,11 @@ async function tizenUninstall({appPackage, udid}) {
   // Total time: 00:00:00.324
 
   const {stdout} = await runTizenCmd(['uninstall', '-p', appPackage, '-s', udid]);
-  if (/uninstall completed/.test(stdout)) {
+  if (/uninstall completed/i.test(stdout)) {
     // ok
     return;
   }
-  if (/Package ID is not valid/.test(stdout)) {
+  if (/Package ID is not valid/i.test(stdout)) {
     // This case could indicate the app does not exist. Ignoring.
     return;
   }

--- a/packages/appium-tizen-tv-driver/lib/cli/tizen.js
+++ b/packages/appium-tizen-tv-driver/lib/cli/tizen.js
@@ -41,8 +41,9 @@ async function tizenInstall({app, udid}) {
   // e.g. Different signature app is already installed.
   const {stdout} = await runTizenCmd(['install', '-n', app, '-s', udid]);
   if (/successfully/.test(stdout)) {
-    throw new Error(`Could not install app ${app}. Stdout from install call was: ${stdout}`);
+    return;
   }
+  throw new Error(`Could not install app ${app}. Stdout from install call was: ${stdout}`);
 }
 
 /**

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -302,10 +302,16 @@ class TizenTVDriver extends BaseDriver {
           // it
           throw new errors.SessionNotCreatedError('For now, the appPackage capability is required');
         }
+        // fast cleanup
         if (!caps.noReset) {
-          await tizenUninstall(
-            /** @type {import('type-fest').SetRequired<typeof caps, 'appPackage'>} */ (caps)
-          );
+          try {
+            await tizenUninstall(
+              /** @type {import('type-fest').SetRequired<typeof caps, 'appPackage'>} */ (caps)
+            );
+          } catch (e) {
+            // Can be ignored. The next installation command will raise an error if this occurs exact error.
+            log.warn(`It might be failed to uninstall ${caps.appPackage}. Please uninstall the installed app by manual if needed. Error: ${e.message}`);
+          }
         }
         // XXX this is for typescript
         await tizenInstall({...caps, app: caps.app});


### PR DESCRIPTION
https://github.com/headspinio/appium-tizen-tv-driver/issues/603 is perhaps a bug in the device side since https://developer.tizen.org/ko/development/tizen-studio/web-tools/running-and-testing-your-app/sdb?langredirect=1#install_uninstall (for example) addresses `sdb uninstall` but it does not work. (no error as well)

This PR tries to emphasize possible error cases as failure so that we could notice them by reading the log.

closes https://github.com/headspinio/appium-tizen-tv-driver/issues/603