### PR TITLE
fix: add mini browser version for non browser info case

### DIFF
--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -503,9 +503,10 @@ class TizenTVDriver extends BaseDriver {
 
   /**
    * Set chrome version v63.0.3239.0 as the minimal version
-   * for autodownload to use proper chromedriver version.
-   * Older than the chromedriver version could raise no Chrome binary found error,
-   * which no makes sense for TV automation usage.
+   * for autodownload to use proper chromedriver version if
+   *     - the 'Browser' info does not have proper chrome version, or
+   *     - older than the chromedriver version could raise no Chrome binary found error,
+   *       which no makes sense for TV automation usage.
    *
    * @param {BrowserVersionInfo} browserVersionInfo
    * @return {BrowserVersionInfo}
@@ -513,6 +514,7 @@ class TizenTVDriver extends BaseDriver {
   fixChromeVersionForAutodownload(browserVersionInfo) {
     const chromeVersion = VERSION_PATTERN.exec(browserVersionInfo.Browser ?? '');
     if (!chromeVersion) {
+      browserVersionInfo.Browser = MIN_CHROME_VERSION;
       return browserVersionInfo;
     }
 
@@ -542,6 +544,7 @@ class TizenTVDriver extends BaseDriver {
         result = await got.get(`http://${debuggerAddress}/json/version`).json();
         log.info(`The response of http://${debuggerAddress}/json/version was ${JSON.stringify(result)}`);
         result = this.fixChromeVersionForAutodownload(result);
+        log.info(`Fixed browser info is ${JSON.stringify(result)}`);
         // To respect the executableDir.
         executable = undefined;
       } catch (err) {

--- a/packages/appium-tizen-tv-driver/test/unit/driver.spec.js
+++ b/packages/appium-tizen-tv-driver/test/unit/driver.spec.js
@@ -107,6 +107,25 @@ describe('TizenTVDriver', function () {
         );
       });
 
+      it('Set minimal chrome version with no browser', function () {
+        const browserInfo = {
+          'Browser': '',
+          'Protocol-Version': '1.2',
+          'User-Agent': 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 4.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 TV Safari/537.36',
+          'WebKit-Version': '537.36 (@24d4006dbb9188e920764a35a60873d6a0157c12)'
+        };
+        expect(
+          driver.fixChromeVersionForAutodownload(browserInfo),
+          'to equal',
+          {
+            'Browser': 'Chrome/63.0.3239.0',
+            'Protocol-Version': '1.2',
+            'User-Agent': 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 4.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 TV Safari/537.36',
+            'WebKit-Version': '537.36 (@24d4006dbb9188e920764a35a60873d6a0157c12)'
+          }
+        );
+      });
+
       it('Use the given chrome version', function () {
         const browserInfo = {
           'Browser': 'Chrome/63.0.3239.0',


### PR DESCRIPTION
As same as https://github.com/headspinio/appium-lg-webos-driver/pull/60 , but this is not necessary for tizentv in current our observation basis