### PR TITLE
feat: extract clearing local data from activateApp with debug: true to clearApp

### DIFF
--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -82,6 +82,8 @@ package in your `package.json`)
 | `appium:isDeviceApiSsl`         | Set it to `true` if you want Appium to connect to the device over SSL.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `appium:rcDebugLog` | Set to `true` to enable debug logs from the interaction with the device's remote control API. |
 | `appium:rcKeypressCooldown` | Cooldown (in milliseconds) after each keypress via remote.  Only applies if `appium:rcMode` is `remote`.  Increase this number if keypress commands complete before the app under test reflects the keypress. Defaults to `750` ms. |
+| `appium:noReset` | If the driver resets the local data of the application under test. It calls `window.localStorage.clear()` and `window.location.reload()` to clear the local data and reload the content. Defaults to `true`.
+| `appium:powerCyclePostUrl` | If the driver cycling the device power with `appium:fullReset` capability. Both capabilities are set, the session creation will try to cycle the device power.
 
 (*) `appium:chromedriverExecutable` or `appium:chromedriverExecutableDir` are required. The chromedriver autodwonload works only when `appium:chromedriverExecutableDir` is provided.
 If both capabilities are given, `appium:chromedriverExecutableDir` take priority.
@@ -217,6 +219,19 @@ driver.execute_script "tizen: activateApp", {appPackage: "biF5E2SN9M.AppiumHelpe
 ```ruby
 # Ruby
 driver.execute_script "tizen: terminateApp", {pkgId: "biF5E2SN9M"}
+```
+
+### Clear the local data of the application under test
+
+> Calls `window.localStorage.clear()` and `window.location.reload()` methods to reset and reload the content.
+
+- `POST /session/:sessionId/execute`
+
+#### Example
+
+```ruby
+# Ruby
+driver.execute_script "tizen: clearApp"
 ```
 
 ### Proxied Commands

--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -223,7 +223,7 @@ driver.execute_script "tizen: terminateApp", {pkgId: "biF5E2SN9M"}
 
 ### Clear the local data of the application under test
 
-> Calls `window.localStorage.clear()` and `window.location.reload()` methods to reset and reload the content.
+> Calls `window.localStorage.clear()` and `window.location.reload()` methods to clear the local data and reload the content of the application under test to reset it.
 
 - `POST /session/:sessionId/execute`
 

--- a/packages/appium-tizen-tv-driver/lib/driver.js
+++ b/packages/appium-tizen-tv-driver/lib/driver.js
@@ -173,6 +173,10 @@ class TizenTVDriver extends BaseDriver {
       command: 'tizentvTerminateApp',
       params: {required: ['pkgId']},
     }),
+    'tizen: clearApp': Object.freeze({
+      command: 'tizentvClearApp',
+      params: {},
+    }),
 
   });
 
@@ -907,8 +911,6 @@ class TizenTVDriver extends BaseDriver {
 
   async #tizentvActivateAppWithDebug(appPackage) {
     const {
-      noReset,
-      appLaunchCooldown,
       chromedriverExecutable,
       chromedriverExecutableDir,
     } = this.caps;
@@ -928,15 +930,6 @@ class TizenTVDriver extends BaseDriver {
       isAutodownloadEnabled: /** @type {Boolean} */ (this.#isChromedriverAutodownloadEnabled()),
     });
     this.#forwardedPortsForChromedriver.push(localDebugPort);
-
-    if (!noReset) {
-      log.info('Waiting for app launch to take effect');
-      await B.delay(/** @type {number} */ (appLaunchCooldown));
-      log.info('Clearing app local storage & reloading...');
-      await this.executeChromedriverScript(SyncScripts.reset);
-      log.info('Waiting for app launch to take effect again post-reload');
-      await B.delay(/** @type {number} */ (appLaunchCooldown));
-    }
   }
 
   /**
@@ -946,6 +939,14 @@ class TizenTVDriver extends BaseDriver {
    */
   async tizentvTerminateApp(pkgId) {
     return await terminateApp({udid: this.opts.udid}, pkgId);
+  }
+
+  /**
+   * Clear the local data of the application under test.
+   */
+  async tizentvClearApp() {
+    log.info('Clearing app local storage & reloading...');
+    await this.executeChromedriverScript(SyncScripts.reset);
   }
 }
 


### PR DESCRIPTION
https://github.com/headspinio/appium-tizen-tv-driver/pull/664 introduced `debug: true` behavior, but it was nice to extract the data clearing behavior from that.