### PR TITLE
feat(tizen-remote): unset if the request got timeout in remote mode

### DIFF
--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -755,8 +755,8 @@ export class TizenRemote extends createdTypedEmitterClass() {
         this.emit(Event.TOKEN, token);
         return token;
       }
-      if (await this.isTokenSupportedDevice()) {
-        throw new Error(`Could not get token; server responded with: ${format('%O', res)}`);
+      if (!(await this.isTokenSupportedDevice())) {
+        throw new Error(`The device does not support token or it could not get token; server responded with: ${format('%O', res)}`);
       }
       this.#debug('The device may not support token as old model.');
       return;

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -630,7 +630,7 @@ export class TizenRemote extends createdTypedEmitterClass() {
    */
   #listenWs(event, listener, {context, once = false} = {}) {
     if (!this.#ws) {
-      throw new Error('Not connected');
+      throw new Error('Failed to establish the websocket connection to the TV device. The rcToken was invalid or might need to be refreshed.');
     }
 
     const method = once ? this.#ws.once : this.#ws.on;

--- a/packages/tizen-remote/lib/tizen-remote.js
+++ b/packages/tizen-remote/lib/tizen-remote.js
@@ -94,6 +94,13 @@ export const constants = /** @type {const} */ ({
   COMMAND_METHOD: 'ms.remote.control',
 
   /**
+   * The `timeout` property in msg payload when sending commands to the Tizen device
+   *
+   * This could occur when the given api token was valid but needs a fresh token?
+   */
+  COMMAND_TIMEOUT: 'ms.channel.timeOut',
+
+  /**
    * The `Event` property in msg payload when requesting a token
    *
    * Likewise the `event` property in a message payload when receiving the new token
@@ -187,6 +194,16 @@ function isKnownBadCode(code) {
  */
 function isTokenMessage(msg) {
   return Boolean(msg?.event === constants.TOKEN_EVENT && msg?.data?.token);
+}
+
+/**
+ * Type guard for incoming messages
+ * @internal
+ * @param {any} msg
+ * @returns {msg is NewTokenMessage}
+ */
+function isCommandTimeout(msg) {
+  return Boolean(msg?.event === constants.COMMAND_TIMEOUT);
 }
 
 /**
@@ -956,6 +973,10 @@ export class TizenRemote extends createdTypedEmitterClass() {
         } else {
           this.#debug('Warning: received token update, but token (%s) is unchanged', this.#token);
         }
+      } else if (isCommandTimeout(msg)) {
+        this.#debug('Received ms.channel.timeOut message. The token (%s) might need a fresh one. ' +
+          'Unset the token to start from a fresh token. Please complete the device paring if needed.', this.#token);
+        this.unsetToken();
       }
     } catch (err) {
       this.#debug('Warning: could not parse message: %s', err);


### PR DESCRIPTION
Adds token unset if the ws got `ms.channel.timeOut`. Typically it occurs when the token is invalid. Ideally... we want to get unauthorized error or something but TVs seem not.

Then, re-using the existing token would keep failing. Instead, requesting a fresh token might be more helpful.