### PR TITLE
Fix noReset Capability Default Value in docs

### DIFF
--- a/packages/appium-tizen-tv-driver/README.md
+++ b/packages/appium-tizen-tv-driver/README.md
@@ -84,7 +84,7 @@ package in your `package.json`)
 | `appium:isDeviceApiSsl` | Set it to `true` if you want Appium to connect to the device over SSL.|
 | `appium:rcDebugLog` | Set to `true` to enable debug logs from the interaction with the device's remote control API. |
 | `appium:rcKeypressCooldown` | Cooldown (in milliseconds) after each keypress via remote.  Only applies if `appium:rcMode` is `remote`.  Increase this number if keypress commands complete before the app under test reflects the keypress. Defaults to `750` ms. |
-| `appium:noReset` | If the driver resets the local data of the application under test. It calls `window.localStorage.clear()` and `window.location.reload()` to clear the local data and reload the content. Defaults to `true`.
+| `appium:noReset` | If the driver resets the local data of the application under test. It calls `window.localStorage.clear()` and `window.location.reload()` to clear the local data and reload the content. Defaults to `false`.
 | `appium:powerCyclePostUrl` | If the driver cycling the device power with `appium:fullReset` capability. Both capabilities are set, the session creation will try to cycle the device power.
 | `appium:sendKeysStrategy` | If the driver uses the device's remote control API to send keys or proxies to the running chromedriver session. `proxy` or `rc` is available. Please read `Set Value (Send Keys)` section below for more details. Default to `undefined`. Please configure it explicitly.
 | `appium:sdbExecTimeout` | Maximum number of milliseconds to wait until a single sdb/tizen command is executed. 90000ms by default


### PR DESCRIPTION
This PR updates the Appium Tizen driver’s README.md to accurately reflect the default value of the appium:noReset capability